### PR TITLE
Support for aws key name & redirect logs for lite-engine

### DIFF
--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -61,6 +61,7 @@ type Config struct {
 		AwsAccessKeyID     string `envconfig:"DRONE_SETTINGS_AWS_ACCESS_KEY_ID"`
 		AwsAccessKeySecret string `envconfig:"DRONE_SETTINGS_AWS_ACCESS_KEY_SECRET"`
 		AwsRegion          string `envconfig:"DRONE_SETTINGS_AWS_REGION"`
+		AwsKeyPairName     string `envconfig:"DRONE_SETTINGS_KEY_PAIR_NAME"`
 		PrivateKeyFile     string `envconfig:"DRONE_SETTINGS_PRIVATE_KEY_FILE"`
 		PublicKeyFile      string `envconfig:"DRONE_SETTINGS_PUBLIC_KEY_FILE"`
 		LiteEnginePath     string `envconfig:"DRONE_SETTINGS_LITE_ENGINE_PATH"`

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -98,6 +98,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 		AwsAccessKeyID:     config.DefaultPoolSettings.AwsAccessKeyID,
 		AwsAccessKeySecret: config.DefaultPoolSettings.AwsAccessKeySecret,
 		AwsRegion:          config.DefaultPoolSettings.AwsRegion,
+		AwsKeyPairName:     config.DefaultPoolSettings.AwsKeyPairName,
 		LiteEnginePath:     config.DefaultPoolSettings.LiteEnginePath,
 		CaCertFile:         config.DefaultPoolSettings.CaCertFile,
 		CertFile:           config.DefaultPoolSettings.CertFile,

--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -101,6 +101,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 		AwsAccessKeyID:     config.DefaultPoolSettings.AwsAccessKeyID,
 		AwsAccessKeySecret: config.DefaultPoolSettings.AwsAccessKeySecret,
 		AwsRegion:          config.DefaultPoolSettings.AwsRegion,
+		AwsKeyPairName:     config.DefaultPoolSettings.AwsKeyPairName,
 		LiteEnginePath:     config.DefaultPoolSettings.LiteEnginePath,
 		CaCertFile:         config.DefaultPoolSettings.CaCertFile,
 		CertFile:           config.DefaultPoolSettings.CertFile,

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/gosimple/slug v1.9.0
-	github.com/harness/lite-engine v0.0.2-0.20211208111525-06599b16e8e0
+	github.com/harness/lite-engine v0.0.2-0.20211217080853-2b4a787dbd83
 	github.com/joho/godotenv v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-isatty v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/harness/lite-engine v0.0.0-20211202150444-b53cdc620e42 h1:vRO2KPZC7Ly
 github.com/harness/lite-engine v0.0.0-20211202150444-b53cdc620e42/go.mod h1:OEqIEuNhB6Ax+7DPX6uqR1iAoucItLGPd/Vc9xX+BNs=
 github.com/harness/lite-engine v0.0.2-0.20211208111525-06599b16e8e0 h1:iUMipAP8tMUVV77LZpTkd05J4fDGnnaKrIwQMHTqBp8=
 github.com/harness/lite-engine v0.0.2-0.20211208111525-06599b16e8e0/go.mod h1:OEqIEuNhB6Ax+7DPX6uqR1iAoucItLGPd/Vc9xX+BNs=
+github.com/harness/lite-engine v0.0.2-0.20211217080853-2b4a787dbd83 h1:QFleOqcA4oJUJd+QJjCTfnme1CifJ7e5swhNeT9giz0=
+github.com/harness/lite-engine v0.0.2-0.20211217080853-2b4a787dbd83/go.mod h1:OEqIEuNhB6Ax+7DPX6uqR1iAoucItLGPd/Vc9xX+BNs=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -113,8 +113,7 @@ restart-service sshd`
 fsutil file createnew "C:\Program Files\lite-engine\.env" 0
 Invoke-WebRequest -Uri "%s/lite-engine.exe" -OutFile "C:\Program Files\lite-engine\lite-engine.exe"
 New-NetFirewallRule -DisplayName "ALLOW TCP PORT 9079" -Direction inbound -Profile Any -Action Allow -LocalPort 9079 -Protocol TCP
-nssm.exe install lite-engine "C:\Program Files\lite-engine\lite-engine.exe" server --env-file="""""""C:\Program Files\lite-engine\.env"""""""
-nssm.exe start lite-engine 
+Start-Process -FilePath "C:\Program Files\lite-engine\lite-engine.exe" -ArgumentList "server --env-file=`+"`"+`"C:\Program Files\lite-engine\.env`+"`"+`"" -RedirectStandardOutput "C:\Program Files\lite-engine\log.out" -RedirectStandardError "C:\Program Files\lite-engine\log.err"
 </powershell>`, params.LiteEnginePath)
 		certs := createWindowsCertsSection(params.CaCertFile, params.CertFile, params.KeyFile, "/tmp/certs")
 		payload = gitKeysInstall + adminAccessSSHRestart + certs + installLE

--- a/internal/vmpool/cloudaws/config_file.go
+++ b/internal/vmpool/cloudaws/config_file.go
@@ -239,6 +239,7 @@ func compilePoolFile(rawPool *poolDefinition, defaultPoolSettings *vmpool.Defaul
 		name:          rawPool.Name,
 		runnerName:    defaultPoolSettings.RunnerName,
 		credentials:   creds,
+		keyPairName:   defaultPoolSettings.AwsKeyPairName,
 		privateKey:    rawPool.Instance.PrivateKey,
 		iamProfileArn: rawPool.Instance.IAMProfileARN,
 		os:            pipelineOS,

--- a/internal/vmpool/cloudaws/pool.go
+++ b/internal/vmpool/cloudaws/pool.go
@@ -30,6 +30,7 @@ type awsPool struct {
 	name        string
 	runnerName  string
 	credentials Credentials
+	keyPairName string
 
 	privateKey    string
 	iamProfileArn string
@@ -213,6 +214,9 @@ func (p *awsPool) Provision(ctx context.Context, tagAsInUse bool) (instance *vmp
 				},
 			},
 		},
+	}
+	if p.keyPairName != "" {
+		in.KeyName = aws.String(p.keyPairName)
 	}
 
 	if p.volumeType == "io1" {

--- a/internal/vmpool/pool.go
+++ b/internal/vmpool/pool.go
@@ -52,6 +52,7 @@ type DefaultSettings struct {
 	AwsAccessKeyID     string
 	AwsAccessKeySecret string
 	AwsRegion          string
+	AwsKeyPairName     string
 	PrivateKeyFile     string
 	PublicKeyFile      string
 	LiteEnginePath     string


### PR DESCRIPTION
1. Added support for aws key name. Key pair can be generated in aws and used for ssh /rdp to ec2 instances. 
2. Redirecting logs for lite-engine in windows vm to a file. 