### PR TITLE
Add support for DRONE_RUNNER_VOLUMES in the Drone AWS runner.

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -37,6 +37,7 @@ type compileCommand struct {
 	Environ map[string]string
 	Secrets map[string]string
 	Config  string
+	Volumes []string
 }
 
 func (c *compileCommand) run(*kingpin.ParseContext) error {
@@ -116,6 +117,7 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 		Environ:     provider.Static(c.Environ),
 		NetworkOpts: nil,
 		Secret:      secret.StaticVars(c.Secrets),
+		Volumes:     c.Volumes,
 		PoolManager: poolManager,
 		Registry:    registry.File(c.Config),
 	}
@@ -155,6 +157,9 @@ func registerCompile(app *kingpin.Application) {
 
 	cmd.Flag("secrets", "secret parameters").
 		StringMapVar(&c.Secrets)
+
+	cmd.Flag("volumes", "drone runner volumes").
+		StringsVar(&c.Volumes)
 
 	cmd.Flag("environ", "environment variables").
 		StringMapVar(&c.Environ)

--- a/command/compile.go
+++ b/command/compile.go
@@ -158,6 +158,8 @@ func registerCompile(app *kingpin.Application) {
 	cmd.Flag("secrets", "secret parameters").
 		StringMapVar(&c.Secrets)
 
+	// Check documentation of DRONE_RUNNER_VOLUMES to see how to
+	// use this param.
 	cmd.Flag("volumes", "drone runner volumes").
 		StringsVar(&c.Volumes)
 

--- a/command/daemon/config.go
+++ b/command/daemon/config.go
@@ -50,6 +50,7 @@ type Config struct {
 		Secrets     map[string]string `envconfig:"DRONE_RUNNER_SECRETS"`
 		Labels      map[string]string `envconfig:"DRONE_RUNNER_LABELS"`
 		NetworkOpts map[string]string `envconfig:"DRONE_RUNNER_NETWORK_OPTS"`
+		Volumes     []string          `envconfig:"DRONE_RUNNER_VOLUMES"`
 	}
 
 	Limit struct {

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -192,6 +192,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 				),
 			),
 			NetworkOpts: env.Runner.NetworkOpts,
+			Volumes:     env.Runner.Volumes,
 			Secret: secret.Combine(
 				secret.StaticVars(
 					env.Runner.Secrets,

--- a/command/delegate/config.go
+++ b/command/delegate/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	}
 
 	Runner struct {
-		Name string `envconfig:"DRONE_RUNNER_NAME"`
+		Name    string   `envconfig:"DRONE_RUNNER_NAME"`
+		Volumes []string `envconfig:"DRONE_RUNNER_VOLUMES"`
 	}
 
 	Settings struct {

--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -485,7 +485,7 @@ func (c *delegateCommand) handleStep(w http.ResponseWriter, r *http.Request) {
 	if reqData.IPAddress != "" {
 		ipAddress = reqData.IPAddress
 	} else {
-		inst, err := c.poolManager.GetUsedInstanceByTag(ctx, reqData.PoolID, TagStageID, reqData.ID) //nolint:govet
+		inst, err := c.poolManager.GetUsedInstanceByTag(ctx, reqData.PoolID, TagStageID, reqData.ID)
 		if err != nil {
 			httprender.InternalError(w, "cannot get the instance by tag", err, logr)
 			return

--- a/command/exec.go
+++ b/command/exec.go
@@ -46,6 +46,7 @@ type execCommand struct {
 	Exclude []string
 	Environ map[string]string
 	Secrets map[string]string
+	Volumes []string
 	Pretty  bool
 	Procs   int64
 	Debug   bool
@@ -131,6 +132,7 @@ func (c *execCommand) run(*kingpin.ParseContext) error { //nolint:gocyclo // its
 		Environ:     provider.Static(c.Environ),
 		NetworkOpts: nil,
 		Secret:      secret.StaticVars(c.Secrets),
+		Volumes:     c.Volumes,
 		PoolManager: poolManager,
 		Registry:    nil,
 	}
@@ -287,6 +289,9 @@ func registerExec(app *kingpin.Application) {
 
 	cmd.Flag("secrets", "secret parameters").
 		StringMapVar(&c.Secrets)
+
+	cmd.Flag("volumes", "drone runner volumes").
+		StringsVar(&c.Volumes)
 
 	cmd.Flag("include", "include pipeline steps").
 		StringsVar(&c.Include)

--- a/command/exec.go
+++ b/command/exec.go
@@ -290,6 +290,8 @@ func registerExec(app *kingpin.Application) {
 	cmd.Flag("secrets", "secret parameters").
 		StringMapVar(&c.Secrets)
 
+	// Check documentation of DRONE_RUNNER_VOLUMES to see how to
+	// use this param.
 	cmd.Flag("volumes", "drone runner volumes").
 		StringsVar(&c.Volumes)
 

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -391,16 +391,11 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 
 	// append global volumes and volume mounts to steps which have an image specified.
 	for _, pair := range c.Volumes {
-		plen := 2
-		z := strings.SplitN(pair, ":", plen)
-		if len(z) != plen {
+		src, dest, ro, err := resource.ParseVolume(pair)
+		id := random()
+		if err != nil {
 			continue
 		}
-		src := z[0]
-		dest := z[1]
-		id := random()
-		ro := strings.HasSuffix(dest, ":ro")
-		dest = strings.TrimSuffix(dest, ":ro")
 		volume := &lespec.Volume{
 			HostPath: &lespec.VolumeHostPath{
 				ID:       id,

--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -391,8 +391,9 @@ func (c *Compiler) Compile(ctx context.Context, args runtime.CompilerArgs) runti
 
 	// append global volumes and volume mounts to steps which have an image specified.
 	for _, pair := range c.Volumes {
-		z := strings.SplitN(pair, ":", 2)
-		if len(z) != 2 {
+		plen := 2
+		z := strings.SplitN(pair, ":", plen)
+		if len(z) != plen {
 			continue
 		}
 		src := z[0]

--- a/engine/resource/volume.go
+++ b/engine/resource/volume.go
@@ -8,15 +8,15 @@ import (
 // ParseVolume parses a volume string of the form <src>:<dest>
 // and returns the source, destination and whether the volume
 // is read only.
-func ParseVolume(v string) (string, string, bool, error) {
+func ParseVolume(v string) (src string, dest string, ro bool, err error) {
 	plen := 2
 	z := strings.SplitN(v, ":", plen)
 	if len(z) != plen {
-		return "", "", false, fmt.Errorf("volume %s is not in the format src:dest", v)
+		return src, dest, ro, fmt.Errorf("volume %s is not in the format src:dest", v)
 	}
-	src := z[0]
-	dest := z[1]
-	ro := strings.HasSuffix(dest, ":ro")
+	src = z[0]
+	dest = z[1]
+	ro = strings.HasSuffix(dest, ":ro")
 	dest = strings.TrimSuffix(dest, ":ro")
 	return src, dest, ro, nil
 }

--- a/engine/resource/volume.go
+++ b/engine/resource/volume.go
@@ -1,0 +1,22 @@
+package resource
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseVolume parses a volume string of the form <src>:<dest>
+// and returns the source, destination and whether the volume
+// is read only.
+func ParseVolume(v string) (string, string, bool, error) {
+	plen := 2
+	z := strings.SplitN(v, ":", plen)
+	if len(z) != plen {
+		return "", "", false, fmt.Errorf("volume %s is not in the format src:dest", v)
+	}
+	src := z[0]
+	dest := z[1]
+	ro := strings.HasSuffix(dest, ":ro")
+	dest = strings.TrimSuffix(dest, ":ro")
+	return src, dest, ro, nil
+}

--- a/engine/resource/volume.go
+++ b/engine/resource/volume.go
@@ -8,7 +8,7 @@ import (
 // ParseVolume parses a volume string of the form <src>:<dest>
 // and returns the source, destination and whether the volume
 // is read only.
-func ParseVolume(v string) (src string, dest string, ro bool, err error) {
+func ParseVolume(v string) (src, dest string, ro bool, err error) {
 	plen := 2
 	z := strings.SplitN(v, ":", plen)
 	if len(z) != plen {

--- a/engine/resource/volume_test.go
+++ b/engine/resource/volume_test.go
@@ -30,6 +30,6 @@ func TestParseVolume_WithRo(t *testing.T) {
 
 func TestParseVolumeError(t *testing.T) {
 	v := "/path/to/src.txt,/path/to/dest.txt"
-	_, _, _, err := ParseVolume(v)
+	_, _, _, err := ParseVolume(v) //nolint:dogsled
 	assert.NotNil(t, err)
 }

--- a/engine/resource/volume_test.go
+++ b/engine/resource/volume_test.go
@@ -1,0 +1,35 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVolume(t *testing.T) {
+	v := "/path/to/src.txt:/path/to/dest.txt"
+	src, dest, ro, err := ParseVolume(v)
+	expSrc := "/path/to/src.txt"
+	expDest := "/path/to/dest.txt"
+	assert.Nil(t, err)
+	assert.Equal(t, src, expSrc)
+	assert.Equal(t, dest, expDest)
+	assert.Equal(t, ro, false)
+}
+
+func TestParseVolume_WithRo(t *testing.T) {
+	v := "/path/to/src.txt:/path/to/dest.txt:ro"
+	src, dest, ro, err := ParseVolume(v)
+	expSrc := "/path/to/src.txt"
+	expDest := "/path/to/dest.txt"
+	assert.Nil(t, err)
+	assert.Equal(t, src, expSrc)
+	assert.Equal(t, dest, expDest)
+	assert.Equal(t, ro, true)
+}
+
+func TestParseVolumeError(t *testing.T) {
+	v := "/path/to/src.txt,/path/to/dest.txt"
+	_, _, _, err := ParseVolume(v)
+	assert.NotNil(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-isatty v0.0.14
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.30.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -36,6 +36,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
@@ -49,7 +50,7 @@ require (
 	github.com/natessilva/dag v0.0.0-20180124060714-7194b8dcc5c4 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.22.4 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d // indirect
@@ -60,4 +61,6 @@ require (
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 // indirect
 	google.golang.org/grpc v1.31.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
This support already exists in the docker and k8s runners.
Ref: https://docs.drone.io/runner/nomad/configuration/reference/drone-runner-volumes/
Sample PR for the k8s runner: https://github.com/drone-runners/drone-runner-kube/pull/24

In the above implementation for k8s, map is used to represent volumes but there can be duplicate sources (eg source 'a' mapping to destinations 'b' and 'c'). Hence changed that to a list here.
Will fix this in the docker and kubernetes runners as well.