### PR TITLE
[POC]: Add support for vm hibernate to reduce costs

### DIFF
--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -318,6 +318,14 @@ func (c *delegateCommand) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if instance.IP == "" {
+		instance, err = c.poolManager.StartInstance(ctx, poolName, instance)
+		if err != nil {
+			httprender.InternalError(w, "failed to start the instance up", err, logr)
+			return
+		}
+	}
+
 	logr = logr.
 		WithField("ip", instance.IP).
 		WithField("id", instance.ID)

--- a/internal/vmpool/cloudaws/pool.go
+++ b/internal/vmpool/cloudaws/pool.go
@@ -537,6 +537,8 @@ func (p *awsPool) Start(ctx context.Context, currInstance *vmpool.Instance) (ins
 		return
 	}
 
+	// TODO: Handle vms that are present in stopping state.
+
 	if currInstance.State == "stopped" {
 		_, err = client.StartInstances(&ec2.StartInstancesInput{InstanceIds: []*string{aws.String(instanceID)}})
 		if err != nil {
@@ -555,10 +557,10 @@ func (p *awsPool) Start(ctx context.Context, currInstance *vmpool.Instance) (ins
 	return
 }
 
+// TODO: WaitWithContext to handle this in a single line. Refer: WaitUntilInstanceRunning
 func (p *awsPool) pollInstanceIPAddr(ctx context.Context, client *ec2.EC2, instanceID string, startTime time.Time, logr logger.Logger) (instance *vmpool.Instance, err error) {
 	// poll the amazon endpoint for server updates
 	// and exit when a network address is allocated.
-
 	attempt := 0
 	intervals := []time.Duration{0, 15 * time.Second, 30 * time.Second, 45 * time.Second, time.Minute}
 

--- a/internal/vmpool/manager.go
+++ b/internal/vmpool/manager.go
@@ -221,6 +221,7 @@ func (m *Manager) buildPool(ctx context.Context, pool *poolEntry) error {
 		go func(ctx context.Context, logr logger.Logger) {
 			defer wg.Done()
 
+			// TODO: Waiting for ip address in a lock may not be a good idea
 			instance, err := pool.Provision(ctx, false)
 			if err != nil {
 				logr.WithError(err).Errorln("build pool: failed to create an instance")
@@ -409,6 +410,7 @@ func (m *Manager) Hibernate(ctx context.Context, poolName, instanceID string) er
 	}
 	time.Sleep(600 * time.Second)
 
+	// TODO: Take lock only to call st
 	pool.Lock()
 	defer pool.Unlock()
 	return pool.Hibernate(ctx, instanceID)

--- a/internal/vmpool/pool.go
+++ b/internal/vmpool/pool.go
@@ -32,6 +32,8 @@ type Pool interface {
 	Tag(ctx context.Context, instanceID string, tags map[string]string) (err error)
 	TagAsInUse(ctx context.Context, instanceID string) (err error)
 	Destroy(ctx context.Context, instanceIDs ...string) (err error)
+	Start(ctx context.Context, currInstance *Instance) (instance *Instance, err error)
+	Hibernate(ctx context.Context, instanceID string) (err error)
 }
 
 // Instance represents a provisioned server instance.
@@ -40,6 +42,7 @@ type Instance struct {
 	IP        string
 	Tags      map[string]string
 	StartedAt time.Time
+	State     string
 }
 
 // Platform defines the target platform.


### PR DESCRIPTION
Currently, pool size number of aws runner vms are always running which increases the build cost. This POC pr takes the approach to hibernate the vm after its bootup is complete. Hibernate is similar to closing the lid of laptop which is restored to earlier state within seconds after starting the instance back. Advantage of hibernated vm is ec2 does not charge for compute of hibernated (stopped) vms. Only storage is charged. This will reduce the cost to use aws runner by upto 90%. 