### PR TITLE
Add stage owner support in pool ownership api

### DIFF
--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -305,7 +305,7 @@ func (c *delegateCommand) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	if err := c.stageOwnerStore.Create(r.Context(), &types.StageOwner{StageID: reqData.ID, Pool: reqData.PoolID}); err != nil {
+	if err := c.stageOwnerStore.Create(r.Context(), &types.StageOwner{StageID: reqData.ID, PoolName: reqData.PoolID}); err != nil {
 		logrus.WithError(err).Errorln("failed to create stage owner entity")
 		httprender.BadRequest(w, "mandatory field 'pool_id' in the request body is empty", nil)
 		return

--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/drone-runners/drone-runner-aws/internal/httprender"
 	"github.com/drone-runners/drone-runner-aws/internal/lehelper"
 	"github.com/drone-runners/drone-runner-aws/internal/poolfile"
+	"github.com/drone-runners/drone-runner-aws/store"
 	"github.com/drone-runners/drone-runner-aws/store/database"
 	"github.com/drone-runners/drone-runner-aws/types"
 	"github.com/drone/runner-go/logger"
@@ -43,12 +44,13 @@ import (
 )
 
 type delegateCommand struct {
-	envFile        string
-	env            config.EnvConfig
-	poolFile       string
-	poolManager    *drivers.Manager
-	runnerName     string
-	liteEnginePath string
+	envFile         string
+	env             config.EnvConfig
+	poolFile        string
+	poolManager     *drivers.Manager
+	stageOwnerStore store.StageOwnerStore
+	runnerName      string
+	liteEnginePath  string
 }
 
 func RegisterDelegate(app *kingpin.Application) {
@@ -116,6 +118,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 	})
 
 	store := database.ProvideInstanceStore(db)
+	c.stageOwnerStore = database.NewStageOwnerStore(db)
 	c.poolManager = drivers.New(ctx, store, c.liteEnginePath, c.runnerName)
 
 	configPool, confErr := poolfile.ConfigPoolFile(c.poolFile, string(types.ProviderAmazon), &env)
@@ -253,11 +256,26 @@ func (c *delegateCommand) handlePoolOwner(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	httprender.OK(w, struct {
+	type poolOwnerResponse struct {
 		Owner bool `json:"owner"`
-	}{
-		Owner: c.poolManager.Exists(poolName),
-	})
+	}
+
+	if !c.poolManager.Exists(poolName) {
+		httprender.OK(w, poolOwnerResponse{Owner: false})
+		return
+	}
+
+	stageId := r.URL.Query().Get("stageId")
+	if stageId != "" {
+		_, err := c.stageOwnerStore.Find(context.Background(), stageId, poolName)
+		if err != nil {
+			logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageId).Trace("failed to find the stage in store")
+			httprender.OK(w, poolOwnerResponse{Owner: false})
+			return
+		}
+	}
+
+	httprender.OK(w, poolOwnerResponse{Owner: true})
 }
 
 func (c *delegateCommand) handleSetup(w http.ResponseWriter, r *http.Request) {
@@ -286,6 +304,12 @@ func (c *delegateCommand) handleSetup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+
+	if err := c.stageOwnerStore.Create(r.Context(), &types.StageOwner{ID: reqData.ID, Pool: reqData.PoolID}); err != nil {
+		logrus.WithError(err).Errorln("failed to create stage owner entity")
+		httprender.BadRequest(w, "mandatory field 'pool_id' in the request body is empty", nil)
+		return
+	}
 
 	// Sets up logger to stream the logs in case log config is set
 	log := logrus.New()
@@ -550,6 +574,10 @@ func (c *delegateCommand) handleDestroy(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	logr.Traceln("destroyed instance")
+
+	if err := c.stageOwnerStore.Delete(r.Context(), reqData.ID); err != nil {
+		logrus.WithError(err).Errorln("failed to delete stage owner entity")
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -305,7 +305,7 @@ func (c *delegateCommand) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	if err := c.stageOwnerStore.Create(r.Context(), &types.StageOwner{ID: reqData.ID, Pool: reqData.PoolID}); err != nil {
+	if err := c.stageOwnerStore.Create(r.Context(), &types.StageOwner{StageID: reqData.ID, Pool: reqData.PoolID}); err != nil {
 		logrus.WithError(err).Errorln("failed to create stage owner entity")
 		httprender.BadRequest(w, "mandatory field 'pool_id' in the request body is empty", nil)
 		return

--- a/command/delegate/delegate.go
+++ b/command/delegate/delegate.go
@@ -117,9 +117,9 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 		cancel()
 	})
 
-	store := database.ProvideInstanceStore(db)
+	instanceStore := database.ProvideInstanceStore(db)
 	c.stageOwnerStore = database.NewStageOwnerStore(db)
-	c.poolManager = drivers.New(ctx, store, c.liteEnginePath, c.runnerName)
+	c.poolManager = drivers.New(ctx, instanceStore, c.liteEnginePath, c.runnerName)
 
 	configPool, confErr := poolfile.ConfigPoolFile(c.poolFile, string(types.ProviderAmazon), &env)
 	if confErr != nil {
@@ -265,11 +265,11 @@ func (c *delegateCommand) handlePoolOwner(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	stageId := r.URL.Query().Get("stageId")
-	if stageId != "" {
-		_, err := c.stageOwnerStore.Find(context.Background(), stageId, poolName)
+	stageID := r.URL.Query().Get("stageId")
+	if stageID != "" {
+		_, err := c.stageOwnerStore.Find(context.Background(), stageID, poolName)
 		if err != nil {
-			logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageId).Trace("failed to find the stage in store")
+			logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageID).Trace("failed to find the stage in store")
 			httprender.OK(w, poolOwnerResponse{Owner: false})
 			return
 		}

--- a/store/database/migrate/postgres/0002_create_table_instances_stageowner.up.sql
+++ b/store/database/migrate/postgres/0002_create_table_instances_stageowner.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS instances (
+     instance_id        VARCHAR(250) PRIMARY KEY
+    ,instance_name      VARCHAR(250)
+    ,instance_address   VARCHAR(250)
+    ,instance_provider  VARCHAR(50)
+    ,instance_state     VARCHAR(50)
+    ,instance_pool      VARCHAR(250)
+    ,instance_image     VARCHAR(250)
+    ,instance_region    VARCHAR(50)
+    ,instance_zone      VARCHAR(50)
+    ,instance_size      VARCHAR(50)
+    ,instance_platform  VARCHAR(50)
+    ,instance_arch      VARCHAR(50)
+    ,instance_stage     INTEGER
+    ,instance_ca_key    TEXT
+    ,instance_ca_cert   TEXT
+    ,instance_tls_key   TEXT
+    ,instance_tls_cert  TEXT
+    ,instance_updated   INTEGER
+    ,instance_started   INTEGER
+    ,is_hibernated      BOOLEAN
+,UNIQUE(instance_name)
+);
+
+CREATE TABLE IF NOT EXISTS stage_owner (
+     stage_id          VARCHAR(250) PRIMARY KEY
+    ,pool_name         VARCHAR(250)
+);

--- a/store/database/migrate/postgres/0002_create_table_instances_stageowner.up.sql
+++ b/store/database/migrate/postgres/0002_create_table_instances_stageowner.up.sql
@@ -1,27 +1,3 @@
-CREATE TABLE IF NOT EXISTS instances (
-     instance_id        VARCHAR(250) PRIMARY KEY
-    ,instance_name      VARCHAR(250)
-    ,instance_address   VARCHAR(250)
-    ,instance_provider  VARCHAR(50)
-    ,instance_state     VARCHAR(50)
-    ,instance_pool      VARCHAR(250)
-    ,instance_image     VARCHAR(250)
-    ,instance_region    VARCHAR(50)
-    ,instance_zone      VARCHAR(50)
-    ,instance_size      VARCHAR(50)
-    ,instance_platform  VARCHAR(50)
-    ,instance_arch      VARCHAR(50)
-    ,instance_stage     INTEGER
-    ,instance_ca_key    TEXT
-    ,instance_ca_cert   TEXT
-    ,instance_tls_key   TEXT
-    ,instance_tls_cert  TEXT
-    ,instance_updated   INTEGER
-    ,instance_started   INTEGER
-    ,is_hibernated      BOOLEAN
-,UNIQUE(instance_name)
-);
-
 CREATE TABLE IF NOT EXISTS stage_owner (
      stage_id          VARCHAR(250) PRIMARY KEY
     ,pool_name         VARCHAR(250)

--- a/store/database/migrate/sqlite/0002_create_table_instances_stageowner.up.sql
+++ b/store/database/migrate/sqlite/0002_create_table_instances_stageowner.up.sql
@@ -1,27 +1,3 @@
-CREATE TABLE IF NOT EXISTS instances (
-     instance_id        VARCHAR(250) PRIMARY KEY
-    ,instance_name      VARCHAR(250)
-    ,instance_address   VARCHAR(250)
-    ,instance_provider  VARCHAR(50)
-    ,instance_state     VARCHAR(50)
-    ,instance_pool      VARCHAR(250)
-    ,instance_image     VARCHAR(250)
-    ,instance_region    VARCHAR(50)
-    ,instance_zone      VARCHAR(50)
-    ,instance_size      VARCHAR(50)
-    ,instance_platform  VARCHAR(50)
-    ,instance_arch      VARCHAR(50)
-    ,instance_stage     INTEGER
-    ,instance_ca_key    BLOB
-    ,instance_ca_cert   BLOB
-    ,instance_tls_key   BLOB
-    ,instance_tls_cert  BLOB
-    ,instance_updated   INTEGER
-    ,instance_started   INTEGER
-    ,is_hibernated      BOOLEAN
-,UNIQUE(instance_name)
-);
-
 CREATE TABLE IF NOT EXISTS stage_owner (
      stage_id          VARCHAR(250) PRIMARY KEY
     ,pool_name         VARCHAR(250)

--- a/store/database/migrate/sqlite/0002_create_table_instances_stageowner.up.sql
+++ b/store/database/migrate/sqlite/0002_create_table_instances_stageowner.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS instances (
+     instance_id        VARCHAR(250) PRIMARY KEY
+    ,instance_name      VARCHAR(250)
+    ,instance_address   VARCHAR(250)
+    ,instance_provider  VARCHAR(50)
+    ,instance_state     VARCHAR(50)
+    ,instance_pool      VARCHAR(250)
+    ,instance_image     VARCHAR(250)
+    ,instance_region    VARCHAR(50)
+    ,instance_zone      VARCHAR(50)
+    ,instance_size      VARCHAR(50)
+    ,instance_platform  VARCHAR(50)
+    ,instance_arch      VARCHAR(50)
+    ,instance_stage     INTEGER
+    ,instance_ca_key    BLOB
+    ,instance_ca_cert   BLOB
+    ,instance_tls_key   BLOB
+    ,instance_tls_cert  BLOB
+    ,instance_updated   INTEGER
+    ,instance_started   INTEGER
+    ,is_hibernated      BOOLEAN
+,UNIQUE(instance_name)
+);
+
+CREATE TABLE IF NOT EXISTS stage_owner (
+     stage_id          VARCHAR(250) PRIMARY KEY
+    ,pool_name         VARCHAR(250)
+);

--- a/store/database/stage_owners.go
+++ b/store/database/stage_owners.go
@@ -1,0 +1,77 @@
+package database
+
+import (
+	"context"
+
+	"github.com/drone-runners/drone-runner-aws/store"
+	"github.com/drone-runners/drone-runner-aws/types"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var _ store.StageOwnerStore = (*StageOwnerStore)(nil)
+
+func NewStageOwnerStore(db *sqlx.DB) *StageOwnerStore {
+	return &StageOwnerStore{db}
+}
+
+type StageOwnerStore struct {
+	db *sqlx.DB
+}
+
+func (s StageOwnerStore) Find(_ context.Context, id, poolName string) (*types.StageOwner, error) {
+	dst := new(types.StageOwner)
+	err := s.db.Get(dst, stageOwnerFindByID, id, poolName)
+	return dst, err
+}
+
+func (s StageOwnerStore) Create(_ context.Context, stageOwner *types.StageOwner) error {
+	query, arg, err := s.db.BindNamed(stageOwnerInsert, stageOwner)
+	if err != nil {
+		return err
+	}
+	return s.db.QueryRow(query, arg...).Scan(&stageOwner.ID)
+}
+
+func (s StageOwnerStore) Delete(ctx context.Context, id string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint
+	if _, err := tx.Exec(stageOwnerDelete, id); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s StageOwnerStore) Purge(ctx context.Context) error {
+	panic("implement me")
+}
+
+const stageOnwerBase = `
+SELECT
+ stage_id
+,pool_name
+FROM stage_owner
+`
+
+const stageOwnerFindByID = stageOnwerBase + `
+WHERE stage_id = $1
+AND pool_name = $2
+`
+
+const stageOwnerInsert = `
+INSERT INTO stage_owner (
+ stage_id
+,pool_name
+) values (
+ :stage_id
+,:pool_name
+) RETURNING stage_id
+`
+
+const stageOwnerDelete = `
+DELETE FROM stage_owner
+WHERE stage_id = $1
+`

--- a/store/database/stage_owners.go
+++ b/store/database/stage_owners.go
@@ -30,7 +30,7 @@ func (s StageOwnerStore) Create(_ context.Context, stageOwner *types.StageOwner)
 	if err != nil {
 		return err
 	}
-	return s.db.QueryRow(query, arg...).Scan(&stageOwner.ID)
+	return s.db.QueryRow(query, arg...).Scan(&stageOwner.StageID)
 }
 
 func (s StageOwnerStore) Delete(ctx context.Context, id string) error {

--- a/store/database/stage_owners_sync.go
+++ b/store/database/stage_owners_sync.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"context"
+
+	"github.com/drone-runners/drone-runner-aws/store/database/mutex"
+
+	"github.com/drone-runners/drone-runner-aws/store"
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+var _ store.StageOwnerStore = (*StageOwnerStoreSync)(nil)
+
+func NewStageOwnerStoreSync(stageOwnerStore *StageOwnerStore) *StageOwnerStoreSync {
+	return &StageOwnerStoreSync{stageOwnerStore}
+}
+
+type StageOwnerStoreSync struct{ base *StageOwnerStore }
+
+func (i StageOwnerStoreSync) Find(ctx context.Context, id, poolName string) (*types.StageOwner, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return i.base.Find(ctx, id, poolName)
+}
+
+func (i StageOwnerStoreSync) Create(ctx context.Context, stageOwner *types.StageOwner) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return i.base.Create(ctx, stageOwner)
+}
+
+func (i StageOwnerStoreSync) Delete(ctx context.Context, s string) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return i.base.Delete(ctx, s)
+}
+
+func (i StageOwnerStoreSync) Purge(ctx context.Context) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	panic("implement me")
+}

--- a/store/database/wire.go
+++ b/store/database/wire.go
@@ -50,3 +50,15 @@ func ProvideInstanceStore(db *sqlx.DB) store.InstanceStore {
 		)
 	}
 }
+
+// ProvideInstanceStore provides an instance store.
+func ProvideStageOwnerStore(db *sqlx.DB) store.StageOwnerStore {
+	switch db.DriverName() {
+	case "postgres":
+		return NewStageOwnerStore(db)
+	default:
+		return NewStageOwnerStoreSync(
+			NewStageOwnerStore(db),
+		)
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -14,3 +14,9 @@ type InstanceStore interface {
 	Update(context.Context, *types.Instance) error
 	Purge(context.Context) error
 }
+
+type StageOwnerStore interface {
+	Find(ctx context.Context, id, poolName string) (*types.StageOwner, error)
+	Create(context.Context, *types.StageOwner) error
+	Delete(context.Context, string) error
+}

--- a/types/types.go
+++ b/types/types.go
@@ -81,6 +81,6 @@ type QueryParams struct {
 }
 
 type StageOwner struct {
-	ID   string `db:"stage_id" json:"stage_id"`
-	Pool string `db:"pool_name" json:"pool_name"`
+	StageID string `db:"stage_id" json:"stage_id"`
+	Pool    string `db:"pool_name" json:"pool_name"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -81,6 +81,6 @@ type QueryParams struct {
 }
 
 type StageOwner struct {
-	StageID string `db:"stage_id" json:"stage_id"`
-	Pool    string `db:"pool_name" json:"pool_name"`
+	StageID  string `db:"stage_id" json:"stage_id"`
+	PoolName string `db:"pool_name" json:"pool_name"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -79,3 +79,8 @@ type QueryParams struct {
 	Status InstanceState
 	Stage  string
 }
+
+type StageOwner struct {
+	ID   string `db:"stage_id" json:"stage_id"`
+	Pool string `db:"pool_name" json:"pool_name"`
+}


### PR DESCRIPTION
Currently only one runner can be the owner of a specific pool in harness CIE. For OSX builds, this is a big limitation since only 2 parallel builds can happen for a pipeline.
To fix this limitation, this change is required. Without this change, cleanup is not guaranteed to happen. Pipeline can be aborted at any time. In case it is aborted just a second after starting up, setup & cleanup call can happen in parallel. We use capability check in CIE to determine which delegate needs to execute a VM setup task. If more than 2 runners are responsible for same pool, stage ownership is added to pool owner api so that cleanup call gets assigned to correct delegate.