### PR TITLE
(feat) have a single instance db for exec / setup.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -54,11 +54,9 @@ func (eng *Engine) Setup(ctx context.Context, specv runtime.Spec) error {
 
 	poolName := spec.CloudInstance.PoolName
 	manager := eng.poolManager
-	stageID := "" // TODO: Check how to obtain this value. Or create value here is it's not yet defined...
 
 	logr := logger.FromContext(ctx).
 		WithField("func", "engine.Setup").
-		WithField("stage", stageID).
 		WithField("pool", spec.CloudInstance.PoolName)
 
 	if poolName == "" {
@@ -103,15 +101,6 @@ func (eng *Engine) Setup(ctx context.Context, specv runtime.Spec) error {
 		}
 	}
 
-	if err != nil {
-		logr.WithError(err).Errorln("failed to unmarshal tags")
-		return err
-	}
-	instance.Stage = stageID
-	if err != nil {
-		logr.WithError(err).Errorln("failed to marshal tags")
-		return err
-	}
 	err = manager.Update(ctx, instance)
 	if err != nil {
 		logr.WithError(err).Errorln("failed to tag")

--- a/store/singleinstance/instances.go
+++ b/store/singleinstance/instances.go
@@ -1,0 +1,50 @@
+package singleinstance
+
+import (
+	"context"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+
+	"github.com/drone-runners/drone-runner-aws/store"
+	"github.com/jmoiron/sqlx"
+)
+
+var (
+	_                 store.InstanceStore = (*InstanceStore)(nil)
+	singletonInstance types.Instance
+)
+
+func NewSingleInstanceStore(db *sqlx.DB) *InstanceStore {
+	return &InstanceStore{db}
+}
+
+type InstanceStore struct {
+	db *sqlx.DB
+}
+
+func (s InstanceStore) Find(_ context.Context, id string) (dst *types.Instance, err error) {
+	return &singletonInstance, nil
+}
+
+func (s InstanceStore) Create(_ context.Context, instance *types.Instance) error {
+	if singletonInstance.ID == "" {
+		singletonInstance = *instance
+	}
+	return nil
+}
+
+func (s InstanceStore) Update(_ context.Context, instance *types.Instance) error {
+	return nil
+}
+
+func (s InstanceStore) Delete(_ context.Context, id string) error {
+	return nil
+}
+
+func (s InstanceStore) List(_ context.Context, pool string, params *types.QueryParams) ([]*types.Instance, error) {
+	return nil, nil
+}
+
+func (s InstanceStore) Purge(ctx context.Context) error {
+	return nil
+}

--- a/test_files/compiler/drone_ubuntu.yml
+++ b/test_files/compiler/drone_ubuntu.yml
@@ -9,20 +9,25 @@ steps:
   - name: check install
     commands:
       - cat /var/log/cloud-init-output.log
-  - name: build binary with golang image
-    image: golang:1.16
-    commands:
-      - GOPATH="" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o release/linux/amd64/drone-runner-aws
+      - hostname -f
+      - ifconfig
+      - touch /tmp/blaaaa
+      - env
   - name: plugin
     image: plugins/docker
     settings:
       dry_run: true
       repo: foo/bar
-      tags: latest
-      dockerfile: docker/Dockerfile.linux.amd64
+      default_suffix: marko
     volumes:
       - name: cache
         path: /go
+  - name: imagey + commands
+    image: golang
+    commands:
+      - go version
+      - go help
+      - ls -al /tmp
   - name: docker status
     commands:
       - docker ps -a
@@ -30,11 +35,14 @@ steps:
     image: redis
     commands:
       - redis-cli -h red ping
-
+  - name: check host volume
+    commands:
+      - ls /tmp
+      
 services:
   - name: red
     image: redis
 
 volumes:
-  - name: cache
-    temp: {}
+- name: cache
+  temp: {}


### PR DESCRIPTION
delegate test
``` 
➜  go-scm git:(no_project) curl -d '{"id": "unique-stage-id","correlation_id":"abc1","pool_id":"ubuntu", "setup_request": {"network": {"id":"drone"}, "platform": { "os":"ubuntu" }}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/setup
{"instance_id":"i-0ad791adb306c1f05","ip_address":"3.145.7.123"}
➜  go-scm git:(no_project) curl -d '{"id":"unique-stage-id","instance_id":"i-0ad791adb306c1f05","pool_id":"ubuntu","correlation_id":"abc1", "start_step_request":{"id":"step4", "image": "alpine:3.11", "working_dir":"/tmp", "run":{"commands":["sleep 30"], "entrypoint":["sh", "-c"]}}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/step
{"exited":true}
➜  go-scm git:(no_project) curl -d '{"id":"id1","pool_id":"ubuntu","correlation_id":"abc1", "instance_id":"i-0ad791adb306c1f05"}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/destroy
```
drone daemon test
<img width="903" alt="image" src="https://user-images.githubusercontent.com/10402706/167881216-5a931c75-563f-4ec2-8a40-b20d5b13a3fa.png">
