### PR TITLE
(DRON-281) daemon can start using env vars

### DIFF
--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/drone-runners/drone-runner-aws/internal/match"
 	"github.com/drone-runners/drone-runner-aws/internal/poolfile"
 	"github.com/drone-runners/drone-runner-aws/store/database"
+	"github.com/drone-runners/drone-runner-aws/types"
 	"github.com/drone/runner-go/client"
 	"github.com/drone/runner-go/environ/provider"
 	"github.com/drone/runner-go/handler/router"
@@ -43,8 +44,8 @@ import (
 var nocontext = context.Background()
 
 type daemonCommand struct {
-	envFile string
-	pool    string
+	envFile  string
+	poolFile string
 }
 
 func (c *daemonCommand) run(*kingpin.ParseContext) error {
@@ -71,8 +72,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	ctx, cancel := context.WithCancel(nocontext)
 	defer cancel()
 
-	// listen for termination signals to gracefully shutdown
-	// the runner daemon.
+	// listen for termination signals to gracefully shutdown the runner daemon.
 	ctx = signal.WithContextFunc(ctx, func() {
 		println("daemon: received signal, terminating process")
 		cancel()
@@ -96,29 +96,25 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	store := database.ProvideInstanceStore(db)
 	poolManager := drivers.New(ctx, store, env.Settings.LiteEnginePath, env.Runner.Name)
 
-	poolFile, err := config.ParseFile(c.pool)
-	if err != nil {
-		logrus.WithError(err).
-			Errorln("daemon: unable to parse pool file")
-		os.Exit(1) //nolint:gocritic // failing fast before we do any work.
+	configPool, confErr := poolfile.ConfigPoolFile(c.poolFile, string(types.ProviderAmazon), &env)
+	if confErr != nil {
+		logrus.WithError(confErr).
+			Fatalln("daemon: unable to load pool file, or use an in memory pool file")
 	}
 
-	pools, err := poolfile.ProcessPool(poolFile, env.Runner.Name)
+	pools, err := poolfile.ProcessPool(configPool, env.Runner.Name)
 	if err != nil {
 		logrus.WithError(err).
-			Errorln("daemon: unable to process pool file")
-		os.Exit(1)
+			Fatalln("daemon: unable to process pool file")
 	}
 	err = poolManager.Add(pools...)
 	if err != nil {
 		logrus.WithError(err).
-			Errorln("daemon: unable to add to the pool")
-		os.Exit(1)
+			Fatalln("daemon: unable to add to the pool")
 	}
 
 	if poolManager.Count() == 0 {
-		logrus.Infoln("daemon: no instance pools found... aborting")
-		os.Exit(1)
+		logrus.Fatalln("daemon: no instance pools found... aborting")
 	}
 
 	err = poolManager.PingProvider(ctx)
@@ -256,7 +252,6 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 		pollerInstance.Poll(ctx, env.Runner.Capacity)
 		return nil
 	})
-
 	// if there is no keyfiles lets remove any old instances.
 	if !env.Settings.ReusePool {
 		cleanErr := poolManager.CleanPools(ctx, true, true)
@@ -271,8 +266,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	err = poolManager.BuildPools(ctx)
 	if err != nil {
 		logrus.WithError(err).
-			Errorln("daemon: unable to build pool")
-		os.Exit(1)
+			Fatalln("daemon: unable to build pool")
 	}
 	logrus.Infoln("daemon: pool created")
 
@@ -324,5 +318,6 @@ func Register(app *kingpin.Application) {
 		Default("").
 		StringVar(&c.envFile)
 	cmd.Flag("pool", "file to seed the pool").
-		StringVar(&c.pool)
+		Default("").
+		StringVar(&c.poolFile)
 }

--- a/command/exec.go
+++ b/command/exec.go
@@ -125,8 +125,8 @@ func (c *execCommand) run(*kingpin.ParseContext) error { //nolint:gocyclo // its
 
 	configPool, confErr := poolfile.ConfigPoolFile(c.PoolFile, c.vmType, &envConfig)
 	if confErr != nil {
-		logrus.WithError(err).
-			Fatalln("Unable to load pool file, or use an in memory pool")
+		logrus.WithError(confErr).
+			Fatalln("exec: unable to load pool file, or use an in memory pool file")
 	}
 
 	pools, err := poolfile.ProcessPool(configPool, runnerName)

--- a/command/setup/setup.go
+++ b/command/setup/setup.go
@@ -23,7 +23,6 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
-	"gopkg.in/yaml.v2"
 )
 
 // empty context.
@@ -173,12 +172,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error {
 	}
 	logrus.WithField("response", fmt.Sprintf("%+v", healthResponse)).Traceln("LE.RetryHealth check complete")
 	// print the pool file
-	marshalledPool, marshalErr := yaml.Marshal(configPool)
-	if marshalErr != nil {
-		logrus.WithError(marshalErr).
-			Errorln("setup: unable to marshal pool file")
-	}
-	fmt.Printf("setup: everything looks good !\npool file:\n%s", marshalledPool)
+	poolfile.PrintPoolFile(configPool)
 	// finally clean the instance
 	destroyErr := poolManager.Destroy(ctx, testPoolName, instance.ID)
 	return destroyErr


### PR DESCRIPTION
```
➜  drone-runner-aws git:(DRON-281) sudo  ntpdate pool.ntp.org
17 May 11:22:59 ntpdate[15251]: step time server 195.171.43.12 offset -0.881551 sec
➜  drone-runner-aws git:(DRON-281) curl -d '{"id": "unique-stage-id","correlation_id":"abc1","pool_id":"ubuntu", "setup_request": {"network": {"id":"drone"}, "platform": { "os":"ubuntu" }}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/setup
{"instance_id":"i-0efdc98a593c81778","ip_address":"3.134.88.219"}
➜  drone-runner-aws git:(DRON-281) curl -d '{"id":"unique-stage-id","instance_id":"i-0efdc98a593c81778","pool_id":"ubuntu","correlation_id":"abc1", "start_step_request":{"id":"step4", "image": "alpine:3.11", "working_dir":"/tmp", "run":{"commands":["sleep 30"], "entrypoint":["sh", "-c"]}}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/step
{"exited":true}
➜  drone-runner-aws git:(DRON-281) curl -d '{"id":"id1","pool_id":"ubuntu","correlation_id":"abc1", "instance_id":"i-0efdc98a593c81778"}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/destroy
➜  drone-runner-aws git:(DRON-281) date
Tue May 17 11:24:46 BST 2022
➜  drone-runner-aws git:(DRON-281)
```