### PR TITLE
(feat) allow min/max pool size to be set from env

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,7 +45,7 @@ steps:
   - name: exec checks
     image: golang:1
     commands:
-      - DRONE_RPC_HOST=not_used DRONE_RPC_SECRET=not_used release/linux/amd64/drone-runner-aws exec test_files/compiler/drone_ubuntu.yml --debug --trace --repo-http='https://github.com/tphoney/bash_plugin' --repo-branch='main' --commit-target='main' --commit-after='7e5f437589cdf071769158ce219b2f443ca13074'
+      - DRONE_MAX_POOL_SIZE=1 DRONE_RPC_HOST=not_used DRONE_RPC_SECRET=not_used release/linux/amd64/drone-runner-aws exec test_files/compiler/drone_ubuntu.yml --debug --trace --repo-http='https://github.com/tphoney/bash_plugin' --repo-branch='main' --commit-target='main' --commit-after='7e5f437589cdf071769158ce219b2f443ca13074'
     environment:
       DRONE_AWS_ACCESS_KEY_ID:
         from_secret: aws_access_key_id

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -183,6 +183,8 @@ type EnvConfig struct {
 	Settings struct {
 		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.1.0/"`
 		ReusePool      bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
+		MinPoolSize    int    `envconfig:"DRONE_MIN_POOL_SIZE" default:"1"`
+		MaxPoolSize    int    `envconfig:"DRONE_MAX_POOL_SIZE" default:"2"`
 	}
 
 	Environ struct {

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -175,7 +175,7 @@ func ConfigPoolFile(filepath, providerType string, conf *config.EnvConfig) (pool
 			if conf.AWS.AccessKeyID == "" || conf.AWS.AccessKeySecret == "" {
 				return pool, fmt.Errorf("%s:missing credentials in env variables 'DRONE_AWS_ACCESS_KEY_ID' and 'DRONE_AWS_ACCESS_KEY_SECRET'", providerType)
 			}
-			return createAmazonPool(conf.AWS.AccessKeyID, conf.AWS.AccessKeySecret), nil
+			return createAmazonPool(conf.AWS.AccessKeyID, conf.AWS.AccessKeySecret, conf.Settings.MinPoolSize, conf.Settings.MaxPoolSize), nil
 
 		default:
 			err = fmt.Errorf("unknown provider type %s, unable to create pool file in memory", providerType)
@@ -198,13 +198,13 @@ func PrintPoolFile(pool *config.PoolFile) {
 	fmt.Printf("Pool file:\n%s\n", marshalledPool)
 }
 
-func createAmazonPool(accessKeyID, accessKeySecret string) *config.PoolFile {
+func createAmazonPool(accessKeyID, accessKeySecret string, minPoolSize, maxPoolSize int) *config.PoolFile {
 	instance := config.Instance{
 		Name:    "test_pool",
 		Default: true,
 		Type:    string(types.ProviderAmazon),
-		Pool:    1,
-		Limit:   1,
+		Pool:    minPoolSize,
+		Limit:   maxPoolSize,
 		Platform: config.Platform{
 			Arch: "amd64",
 			OS:   "linux",


### PR DESCRIPTION
```
➜  drone-runner-aws git:(min_max) ✗ date
Tue May 17 14:35:11 BST 2022
➜  drone-runner-aws git:(min_max) ✗ curl -d '{"id": "unique-stage-id","correlation_id":"abc1","pool_id":"ubuntu", "setup_request": {"network": {"id":"drone"}, "platform": { "os":"ubuntu" }}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/setup
{"error_msg":"pool not defined"}
➜  drone-runner-aws git:(min_max) ✗ curl -d '{"id": "unique-stage-id","correlation_id":"abc1","pool_id":"test_pool", "setup_request": {"network": {"id":"drone"}, "platform": { "os":"ubuntu" }}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/setup
{"instance_id":"i-044ead40274a7673a","ip_address":"3.139.61.255"}
➜  drone-runner-aws git:(min_max) ✗ curl -d '{"id":"unique-stage-id","instance_id":"i-044ead40274a7673a","pool_id":"test_pool","correlation_id":"abc1", "start_step_request":{"id":"step4", "image": "alpine:3.11", "working_dir":"/tmp", "run":{"commands":["sleep 30"], "entrypoint":["sh", "-c"]}}}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/step
{"exited":true}
➜  drone-runner-aws git:(min_max) ✗ curl -d '{"id":"id1","pool_id":"test_pool","correlation_id":"abc1", "instance_id":"i-044ead40274a7673a"}' -H "Content-Type: application/json" -X POST  http://127.0.0.1:3000/destroy
➜  drone-runner-aws git:(min_max) ✗ date
Tue May 17 14:39:39 BST 2022
➜  drone-runner-aws git:(min_max) ✗
```