### PR TITLE
(fixes)  dron-285 - fixes issues with anka & adds purger to daemon

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -183,6 +183,8 @@ type EnvConfig struct {
 	Settings struct {
 		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.1.0/"`
 		ReusePool      bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
+		BusyMaxAge     int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`
+		FreeMaxAge     int64  `envconfig:"DRONE_SETTINGS_FREE_MAX_AGE" default:"720"`
 	}
 
 	Environ struct {

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -128,6 +128,15 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 		return err
 	}
 
+	busyMaxAge := time.Hour * time.Duration(env.Settings.BusyMaxAge) // includes time required to setup an instance
+	freeMaxAge := time.Hour * time.Duration(env.Settings.FreeMaxAge)
+	err = poolManager.StartInstancePurger(ctx, busyMaxAge, freeMaxAge)
+	if err != nil {
+		logrus.WithError(err).
+			Errorln("delegate: failed to start instance purger")
+		return err
+	}
+
 	opts := engine.Opts{
 		Repopulate: true,
 	}


### PR DESCRIPTION
* adds purger to daemon
* fixes the issue, where destroy, was getting called twice, once as a goroutine & in runner.go execer command
* adds context to command calls on anka - was causing failures not to surface, threads getting lost

tickets:
- https://harness.atlassian.net/browse/DRON-285
- https://harness.atlassian.net/browse/DRON-283

Delegate Tests:

<img width="1470" alt="Screenshot 2022-05-17 at 16 57 09" src="https://user-images.githubusercontent.com/83226740/168855797-0c6e7230-b09a-42a9-bf51-ef8cd56770cc.png">

