### PR TITLE
Fix instance name in gcp runner

### DIFF
--- a/command/harness/dlite/execute.go
+++ b/command/harness/dlite/execute.go
@@ -46,6 +46,7 @@ func (t *VMExecuteTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	req.ExecuteVMRequest.CorrelationID = task.ID
 	resp, err := harness.HandleStep(ctx, &req.ExecuteVMRequest, &t.c.env, t.c.poolManager)
 	if err != nil {
 		logr.WithError(err).Error("could not execute step:")

--- a/command/harness/dlite/init.go
+++ b/command/harness/dlite/init.go
@@ -47,6 +47,7 @@ func (t *VMInitTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Make the setup call
+	req.SetupVMRequest.CorrelationID = task.ID
 	setupResp, err := harness.HandleSetup(ctx, &req.SetupVMRequest, t.c.stageOwnerStore, &t.c.env, t.c.poolManager)
 	if err != nil {
 		logr.WithError(err).Error("could not setup VM")
@@ -60,6 +61,7 @@ func (t *VMInitTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Start all the services
 	for i, s := range req.Services {
 		req.Services[i].IPAddress = setupResp.IPAddress
+		req.Services[i].CorrelationID = task.ID
 		status = VMServiceStatus{ID: s.ID, Name: s.Name, Image: s.Image, LogKey: s.LogKey, Status: Running, ErrorMessage: ""}
 		resp, err := harness.HandleStep(ctx, req.Services[i], &t.c.env, t.c.poolManager)
 		if err != nil {

--- a/internal/drivers/google/driver.go
+++ b/internal/drivers/google/driver.go
@@ -398,5 +398,5 @@ func getInstanceName(runner, pool string) string {
 	name := strings.ToLower(fmt.Sprintf("%s-%s-%d-%s", namePrefix, pool,
 		time.Now().Unix(), randStr))
 
-	return substrStrPrefix(name, maxInstanceNameLen)
+	return substrSuffix(name, maxInstanceNameLen)
 }

--- a/internal/drivers/google/driver.go
+++ b/internal/drivers/google/driver.go
@@ -22,6 +22,11 @@ import (
 	"google.golang.org/api/option"
 )
 
+const (
+	maxInstanceNameLen = 63
+	randStrLen         = 5
+)
+
 var (
 	defaultTags = []string{
 		"allow-docker",
@@ -389,8 +394,9 @@ func (p *config) waitGlobalOperation(ctx context.Context, name string) error {
 // [a-z]([-a-z0-9]*[a-z0-9])?
 func getInstanceName(runner, pool string) string {
 	namePrefix := strings.ReplaceAll(runner, " ", "")
+	randStr, _ := randStringRunes(randStrLen)
 	name := strings.ToLower(fmt.Sprintf("%s-%s-%d-%s", namePrefix, pool,
-		time.Now().Unix(), randStringRunes(5)))
+		time.Now().Unix(), randStr))
 
-	return substrStrPrefix(name, 63)
+	return substrStrPrefix(name, maxInstanceNameLen)
 }

--- a/internal/drivers/google/util.go
+++ b/internal/drivers/google/util.go
@@ -1,0 +1,23 @@
+package google
+
+import "math/rand"
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+// substrStrPrefix removes additional characters from prefix
+// if input string size is greater than input max length
+func substrStrPrefix(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+
+	return s[len(s)-maxLen:]
+}

--- a/internal/drivers/google/util.go
+++ b/internal/drivers/google/util.go
@@ -20,9 +20,9 @@ func randStringRunes(n int) (string, error) {
 	return string(ret), nil
 }
 
-// substrStrPrefix removes additional characters from prefix
+// substrSuffix removes additional characters from prefix
 // if input string size is greater than input max length
-func substrStrPrefix(s string, maxLen int) string {
+func substrSuffix(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}

--- a/internal/drivers/google/util.go
+++ b/internal/drivers/google/util.go
@@ -1,15 +1,23 @@
 package google
 
-import "math/rand"
+import (
+	"crypto/rand"
+	"math/big"
+)
 
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+const letters = "0123456789abcdefghijklmnopqrstuvwxyz"
 
-func randStringRunes(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+func randStringRunes(n int) (string, error) {
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
 	}
-	return string(b)
+
+	return string(ret), nil
 }
 
 // substrStrPrefix removes additional characters from prefix

--- a/internal/drivers/google/util_test.go
+++ b/internal/drivers/google/util_test.go
@@ -1,0 +1,23 @@
+package google
+
+import (
+	"testing"
+)
+
+func Test_substrStrPrefix(t *testing.T) {
+	tests := []struct {
+		s        string
+		maxLen   int
+		expected string
+	}{
+		{s: "hello", maxLen: 63, expected: "hello"},
+		{s: "hello", maxLen: 2, expected: "lo"},
+		{s: "hello", maxLen: 5, expected: "hello"},
+	}
+
+	for _, test := range tests {
+		if got, want := substrStrPrefix(test.s, test.maxLen), test.expected; got != want {
+			t.Errorf("Want substring %s, got %s", want, got)
+		}
+	}
+}

--- a/internal/drivers/google/util_test.go
+++ b/internal/drivers/google/util_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_substrStrPrefix(t *testing.T) {
+func Test_substrSuffix(t *testing.T) {
 	tests := []struct {
 		s        string
 		maxLen   int
@@ -16,7 +16,7 @@ func Test_substrStrPrefix(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, want := substrStrPrefix(test.s, test.maxLen), test.expected; got != want {
+		if got, want := substrSuffix(test.s, test.maxLen), test.expected; got != want {
 			t.Errorf("Want substring %s, got %s", want, got)
 		}
 	}

--- a/internal/drivers/manager.go
+++ b/internal/drivers/manager.go
@@ -453,6 +453,7 @@ func (m *Manager) buildPool(ctx context.Context, pool *poolEntry) error {
 			logr.
 				WithField("pool", pool.Name).
 				WithField("id", inst.ID).
+				WithField("name", inst.Name).
 				Infoln("build pool: created new instance")
 
 			go func() {

--- a/main.go
+++ b/main.go
@@ -5,16 +5,9 @@
 package main
 
 import (
-	"math/rand"
-	"time"
-
 	"github.com/drone-runners/drone-runner-aws/command"
 	_ "github.com/joho/godotenv/autoload"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func main() {
 	command.Command()

--- a/main.go
+++ b/main.go
@@ -5,9 +5,16 @@
 package main
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/drone-runners/drone-runner-aws/command"
 	_ "github.com/joho/godotenv/autoload"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func main() {
 	command.Command()


### PR DESCRIPTION
In case pool size of more than 1 was selected, instance name collision was taking place which was failing instance creation.
`ERRO[0009] manager: failed to create instance            error="googleapi: Error 409: The resource 'projects/ci-play/zones/us-central1-a/instances/shubhamagrawal-ubuntu-gcp-shubham-1658843098' already exists, alreadyExists"`

Also, removed spaces in instance name. 

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
