### PR TITLE
(feat) Inject split test binary for Linux VMs (CIE)

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -279,14 +279,15 @@ type EnvConfig struct {
 	}
 
 	Settings struct {
-		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.3/"`
-		DefaultDriver  string `envconfig:"DRONE_DEFAULT_DRIVER" default:"amazon"`
-		ReusePool      bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
-		BusyMaxAge     int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`
-		FreeMaxAge     int64  `envconfig:"DRONE_SETTINGS_FREE_MAX_AGE" default:"720"`
-		MinPoolSize    int    `envconfig:"DRONE_MIN_POOL_SIZE" default:"1"`
-		MaxPoolSize    int    `envconfig:"DRONE_MAX_POOL_SIZE" default:"2"`
-		EnableAutoPool bool   `envconfig:"DRONE_ENABLE_AUTO_POOL" default:"false"`
+		LiteEnginePath       string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.3/"`
+		DefaultDriver        string `envconfig:"DRONE_DEFAULT_DRIVER" default:"amazon"`
+		ReusePool            bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
+		BusyMaxAge           int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`
+		FreeMaxAge           int64  `envconfig:"DRONE_SETTINGS_FREE_MAX_AGE" default:"720"`
+		MinPoolSize          int    `envconfig:"DRONE_MIN_POOL_SIZE" default:"1"`
+		MaxPoolSize          int    `envconfig:"DRONE_MAX_POOL_SIZE" default:"2"`
+		EnableAutoPool       bool   `envconfig:"DRONE_ENABLE_AUTO_POOL" default:"false"`
+		HarnessTestBinaryURI string `envconfig:"DRONE_HARNESS_TEST_BINARY_URI"`
 	}
 
 	Server struct {

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -100,7 +100,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 		),
 	)
 	store := database.ProvideInstanceStore(db)
-	poolManager := drivers.New(ctx, store, env.Settings.LiteEnginePath, env.Runner.Name)
+	poolManager := drivers.New(ctx, store, &env)
 
 	configPool, confErr := poolfile.ConfigPoolFile(c.poolFile, &env)
 	if confErr != nil {

--- a/command/exec.go
+++ b/command/exec.go
@@ -139,7 +139,9 @@ func (c *execCommand) run(*kingpin.ParseContext) error { //nolint:gocyclo // its
 	}
 	store := database.ProvideInstanceStore(db)
 
-	poolManager := drivers.New(ctx, store, c.LiteEngineURL, runnerName)
+	envConfig.Settings.LiteEnginePath = c.LiteEngineURL
+	envConfig.Runner.Name = runnerName
+	poolManager := drivers.New(ctx, store, &envConfig)
 	err = poolManager.Add(pools...)
 	if err != nil {
 		return err

--- a/command/harness/delegate/delegate.go
+++ b/command/harness/delegate/delegate.go
@@ -70,6 +70,9 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
+	if env.Settings.HarnessTestBinaryURI == "" {
+		env.Settings.HarnessTestBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/split_tests"
+	}
 	c.env = env
 	// setup the global logrus logger.
 	harness.SetupLogger(&c.env)
@@ -89,7 +92,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 
 	instanceStore := database.ProvideInstanceStore(db)
 	c.stageOwnerStore = database.ProvideStageOwnerStore(db)
-	c.poolManager = drivers.New(ctx, instanceStore, c.env.Settings.LiteEnginePath, c.env.Runner.Name)
+	c.poolManager = drivers.New(ctx, instanceStore, &c.env)
 
 	_, err = harness.SetupPool(ctx, &c.env, c.poolManager, c.poolFile)
 	defer harness.Cleanup(&c.env, c.poolManager) //nolint: errcheck

--- a/command/harness/dlite/dlite.go
+++ b/command/harness/dlite/dlite.go
@@ -81,6 +81,9 @@ func (c *dliteCommand) run(*kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
+	if env.Settings.HarnessTestBinaryURI == "" {
+		env.Settings.HarnessTestBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/split_tests"
+	}
 	c.env = env
 	// setup the global logrus logger.
 	harness.SetupLogger(&c.env)
@@ -99,7 +102,7 @@ func (c *dliteCommand) run(*kingpin.ParseContext) error {
 
 	instanceStore := database.ProvideInstanceStore(db)
 	c.stageOwnerStore = database.ProvideStageOwnerStore(db)
-	c.poolManager = drivers.New(ctx, instanceStore, c.env.Settings.LiteEnginePath, c.env.Runner.Name)
+	c.poolManager = drivers.New(ctx, instanceStore, &c.env)
 
 	poolConfig, err := harness.SetupPool(ctx, &c.env, c.poolManager, c.poolFile)
 	defer harness.Cleanup(&c.env, c.poolManager) //nolint: errcheck

--- a/command/setup/setup.go
+++ b/command/setup/setup.go
@@ -135,7 +135,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 	)
 
 	store := database.ProvideInstanceStore(db)
-	poolManager := drivers.New(ctx, store, env.Settings.LiteEnginePath, runnerName)
+	poolManager := drivers.New(ctx, store, &env)
 
 	configPool, confErr := poolfile.ConfigPoolFile("", &env)
 	if confErr != nil {

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -20,11 +20,12 @@ import (
 
 // Params defines parameters used to create userdata files.
 type Params struct {
-	LiteEnginePath string
-	CACert         string
-	TLSCert        string
-	TLSKey         string
-	Platform       types.Platform
+	LiteEnginePath       string
+	CACert               string
+	TLSCert              string
+	TLSKey               string
+	Platform             types.Platform
+	HarnessTestBinaryURI string
 }
 
 var funcs = map[string]interface{}{
@@ -177,6 +178,10 @@ runcmd:
 - 'ufw allow 9079'
 - 'wget "{{ .LiteEnginePath }}/lite-engine-{{ .Platform.OS }}-{{ .Platform.Arch }}" -O /usr/bin/lite-engine'
 - 'chmod 777 /usr/bin/lite-engine'
+{{ if .HarnessTestBinaryURI }}
+- 'wget "{{ .HarnessTestBinaryURI }}/{{ .Platform.Arch }}/{{ .Platform.OS }}/bin/split_tests-{{ .Platform.OS }}_{{ .Platform.Arch }}" -O /usr/bin/split_tests'
+- 'chmod 777 /usr/bin/split_tests'
+{{ end }}
 - 'touch /root/.env'
 - '[ -f "/etc/environment" ] && cp "/etc/environment" /root/.env'
 - '/usr/bin/lite-engine server --env-file /root/.env > /var/log/lite-engine.log 2>&1 &'`

--- a/internal/lehelper/lehelper.go
+++ b/internal/lehelper/lehelper.go
@@ -15,11 +15,12 @@ const (
 
 func GenerateUserdata(userdata string, opts *types.InstanceCreateOpts) string {
 	var params = cloudinit.Params{
-		Platform:       opts.Platform,
-		CACert:         string(opts.CACert),
-		TLSCert:        string(opts.TLSCert),
-		TLSKey:         string(opts.TLSKey),
-		LiteEnginePath: opts.LiteEnginePath,
+		Platform:             opts.Platform,
+		CACert:               string(opts.CACert),
+		TLSCert:              string(opts.TLSCert),
+		TLSKey:               string(opts.TLSKey),
+		LiteEnginePath:       opts.LiteEnginePath,
+		HarnessTestBinaryURI: opts.HarnessTestBinaryURI,
 	}
 
 	if userdata == "" {

--- a/types/types.go
+++ b/types/types.go
@@ -62,10 +62,11 @@ type InstanceCreateOpts struct {
 	TLSCert        []byte
 	LiteEnginePath string
 	Platform
-	PoolName   string
-	RunnerName string
-	Limit      int
-	Pool       int
+	PoolName             string
+	RunnerName           string
+	Limit                int
+	Pool                 int
+	HarnessTestBinaryURI string
 }
 
 // Platform defines the target platform.


### PR DESCRIPTION
## Summary
This PR downloads split test binary for Ubuntu Linux VMs where the driver is either delegate or dlite. It is downloaded from a GCS bucket where the binary is uploaded by the CIE Build Release pipelines. This is achieved by updating the cloudinit script for Ubuntu VMs which means the binary will be downloaded as part of VM startup. It also includes a minor refactor where the environment config is passed to the driver instead of individual parameters as suggested which includes updating a few structs as well.

## Local Test
Evidence for binary being present (downloaded) in the VM:
![image](https://user-images.githubusercontent.com/103484777/189770859-0c157d6f-e981-4b7f-9a9d-d36dfc47b2fd.png)

