### PR TITLE
Set machine environment variables to lite-engine

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -279,7 +279,7 @@ type EnvConfig struct {
 	}
 
 	Settings struct {
-		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://a643-125-19-67-142.ngrok.io"`
+		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.1/"`
 		DefaultDriver  string `envconfig:"DRONE_DEFAULT_DRIVER" default:"amazon"`
 		ReusePool      bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
 		BusyMaxAge     int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -279,7 +279,7 @@ type EnvConfig struct {
 	}
 
 	Settings struct {
-		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.1/"`
+		LiteEnginePath string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://a643-125-19-67-142.ngrok.io"`
 		DefaultDriver  string `envconfig:"DRONE_DEFAULT_DRIVER" default:"amazon"`
 		ReusePool      bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
 		BusyMaxAge     int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -173,10 +173,12 @@ write_files:
   encoding: b64
   content: {{ .TLSKey | base64 }}
 runcmd:
+- 'set -x'
 - 'ufw allow 9079'
 - 'wget "{{ .LiteEnginePath }}/lite-engine-{{ .Platform.OS }}-{{ .Platform.Arch }}" -O /usr/bin/lite-engine'
 - 'chmod 777 /usr/bin/lite-engine'
 - 'touch /root/.env'
+- '[ -f "/etc/environment" ] && cp "/etc/environment" /root/.env'
 - '/usr/bin/lite-engine server --env-file /root/.env > /var/log/lite-engine.log 2>&1 &'`
 
 var ubuntuTemplate = template.Must(template.New(oshelp.OSLinux).Funcs(funcs).Parse(ubuntuScript))


### PR DESCRIPTION
Host machine environment variables present on bootup are not present in cloud init script process. Hence, environment variables of host machine are not set. So, tools installed on host machine are not accessible to steps as well. 
This PR sets the environment variables of host machine to file /root/.env for ubuntu which is read by lite-engine and set appropriately.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
