### PR TITLE
fixes issue with timestamp being used on machine name & allow session…

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -52,6 +52,7 @@ type (
 	AmazonAccount struct {
 		AccessKeyID      string `json:"access_key_id,omitempty"  yaml:"access_key_id"`
 		AccessKeySecret  string `json:"access_key_secret,omitempty" yaml:"access_key_secret"`
+		SessionToken     string `json:"aws_session_token,omitempty" yaml:"aws_session_token"`
 		Region           string `json:"region,omitempty"`
 		Retries          int    `json:"retries,omitempty" yaml:"retries,omitempty"`
 		AvailabilityZone string `json:"availability_zone,omitempty" yaml:"availability_zone,omitempty"`

--- a/internal/drivers/amazon/driver.go
+++ b/internal/drivers/amazon/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/cenkalti/backoff/v4"
+	"github.com/dchest/uniuri"
 )
 
 // config is a struct that implements drivers.Pool interface
@@ -31,6 +32,7 @@ type config struct {
 
 	accessKeyID     string
 	secretAccessKey string
+	sessionToken    string
 	keyPairName     string
 
 	rootDir string
@@ -67,7 +69,11 @@ func New(opts ...Option) (drivers.Driver, error) {
 			MaxRetries: aws.Int(p.retries),
 		}
 		if p.accessKeyID != "" && p.secretAccessKey != "" {
-			config.Credentials = credentials.NewStaticCredentials(p.accessKeyID, p.secretAccessKey, "")
+			if p.sessionToken != "" {
+				config.Credentials = credentials.NewStaticCredentials(p.accessKeyID, p.secretAccessKey, p.sessionToken)
+			} else {
+				config.Credentials = credentials.NewStaticCredentials(p.accessKeyID, p.secretAccessKey, "")
+			}
 		}
 		mySession := session.Must(session.NewSession())
 		p.service = ec2.New(mySession, config)
@@ -186,7 +192,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		WithField("image", p.image).
 		WithField("size", p.size).
 		WithField("hibernate", p.CanHibernate())
-	var name = fmt.Sprintf(opts.RunnerName+"-"+opts.PoolName+"-%d", startTime.Unix())
+	var name = fmt.Sprintf(opts.RunnerName + uniuri.NewLen(8)) //nolint
 	var tags = map[string]string{
 		"Name": name,
 	}

--- a/internal/drivers/amazon/option.go
+++ b/internal/drivers/amazon/option.go
@@ -51,6 +51,13 @@ func WithSecretAccessKey(secretAccessKey string) Option {
 	}
 }
 
+// WithSessionToken returns an option to set the session token.
+func WithSessionToken(sessionToken string) Option {
+	return func(p *config) {
+		p.sessionToken = sessionToken
+	}
+}
+
 // WithRootDirectory sets the root directory for the virtual machine.
 func WithRootDirectory(dir string) Option {
 	return func(p *config) {

--- a/internal/drivers/anka/driver.go
+++ b/internal/drivers/anka/driver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/drone-runners/drone-runner-aws/types"
 	"github.com/drone/runner-go/logger"
 
+	"github.com/dchest/uniuri"
 	"github.com/sirupsen/logrus"
 )
 
@@ -68,7 +68,7 @@ func (p *config) CanHibernate() bool {
 func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (instance *types.Instance, err error) {
 	startTime := time.Now()
 	uData := lehelper.GenerateUserdata(p.userData, opts)
-	machineName := fmt.Sprintf(opts.RunnerName+"-"+"-%d", rand.Int()) //nolint
+	machineName := fmt.Sprintf(opts.RunnerName + uniuri.NewLen(8)) //nolint
 
 	logr := logger.FromContext(ctx).
 		WithField("cloud", types.Anka).

--- a/internal/drivers/azure/driver.go
+++ b/internal/drivers/azure/driver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/dchest/uniuri"
 )
 
 type config struct {
@@ -109,8 +110,7 @@ func (c *config) Zones() string {
 func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (instance *types.Instance, err error) {
 	sanitizedRunnerName := strings.ReplaceAll(opts.RunnerName, " ", "-")
 	sanitizedPoolName := strings.ReplaceAll(opts.PoolName, " ", "-")
-	var name = fmt.Sprintf("%s-%s-%d", sanitizedRunnerName, sanitizedPoolName, time.Now().Unix())
-
+	var name = fmt.Sprintf("%s-%s-%s", sanitizedRunnerName, sanitizedPoolName, uniuri.NewLen(8)) //nolint
 	vnetName := fmt.Sprintf("%s-vnet", name)
 	subnetName := fmt.Sprintf("%s-subnet", name)
 	publicIPName := fmt.Sprintf("%s-publicip", name)

--- a/internal/drivers/digitalocean/driver.go
+++ b/internal/drivers/digitalocean/driver.go
@@ -10,9 +10,10 @@ import (
 	"github.com/drone-runners/drone-runner-aws/internal/lehelper"
 	"github.com/drone-runners/drone-runner-aws/types"
 	"github.com/drone/runner-go/logger"
-	"golang.org/x/oauth2"
 
+	"github.com/dchest/uniuri"
 	"github.com/digitalocean/godo"
+	"golang.org/x/oauth2"
 )
 
 // config is a struct that implements drivers.Pool interface
@@ -69,7 +70,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		WithField("pool", opts.PoolName).
 		WithField("image", p.image).
 		WithField("hibernate", p.CanHibernate())
-	var name = fmt.Sprintf(opts.RunnerName+"-"+opts.PoolName+"-%d", startTime.Unix())
+	var name = fmt.Sprintf(opts.RunnerName+"-"+opts.PoolName+"-%d", uniuri.NewLen(8)) //nolint
 	logr.Infof("digitalocean: creating instance %s", name)
 
 	// create a new digitalocean request

--- a/internal/drivers/google/driver.go
+++ b/internal/drivers/google/driver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/drone-runners/drone-runner-aws/types"
 	"github.com/drone/runner-go/logger"
 
+	"github.com/dchest/uniuri"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -496,8 +497,8 @@ func (p *config) waitGlobalOperation(ctx context.Context, name string) error {
 func getInstanceName(runner, pool string) string {
 	namePrefix := strings.ReplaceAll(runner, " ", "")
 	randStr, _ := randStringRunes(randStrLen)
-	name := strings.ToLower(fmt.Sprintf("%s-%s-%d-%s", namePrefix, pool,
-		time.Now().Unix(), randStr))
+	name := strings.ToLower(fmt.Sprintf("%s-%s-%s-%s", namePrefix, pool,
+		uniuri.NewLen(8), randStr)) //nolint
 
 	return substrSuffix(name, maxInstanceNameLen)
 }

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -77,6 +77,7 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string) ([]drivers.Pool, 
 			var driver, err = amazon.New(
 				amazon.WithAccessKeyID(a.Account.AccessKeyID),
 				amazon.WithSecretAccessKey(a.Account.AccessKeySecret),
+				amazon.WithSessionToken(a.Account.SessionToken),
 				amazon.WithZone(a.Account.AvailabilityZone),
 				amazon.WithKeyPair(a.Account.KeyPairName),
 				amazon.WithDeviceName(a.DeviceName, instance.Platform.OSName),


### PR DESCRIPTION
Fixes:
1. Pass in optional session token for AWS creds
2. Remove timestamp from instance name creation - issues if lots of VMS spun up at once. Name has to be unique. 