### PR TITLE
Upgraded lite engine to v0.4.8 (where docker client is downgraded)

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -287,7 +287,7 @@ type EnvConfig struct {
 	}
 
 	Settings struct {
-		LiteEnginePath       string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.7/"`
+		LiteEnginePath       string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.4.8/"`
 		DefaultDriver        string `envconfig:"DRONE_DEFAULT_DRIVER" default:"amazon"`
 		ReusePool            bool   `envconfig:"DRONE_REUSE_POOL" default:"false"`
 		BusyMaxAge           int64  `envconfig:"DRONE_SETTINGS_BUSY_MAX_AGE" default:"24"`


### PR DESCRIPTION
This change upgrades the lite engine to v0.4.8 version. 
The v0.4.8 version has downgraded version of docker client, this change was necessary in order for gcp vms to work with windows. The reason being Vms were at a lower docker client version which was resulting in issues for windows vms.