### PR TITLE
Add prefix to hostname while setting default runner name

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"unicode"
+	utf8 "unicode/utf8"
 
 	"github.com/drone-runners/drone-runner-aws/types"
 
@@ -400,7 +401,8 @@ func FromEnviron() (EnvConfig, error) {
 	if config.Runner.Name == "" {
 		hostname, _ := os.Hostname()
 		hostname = strings.ToLower(hostname)
-		if hostname == "" || !unicode.IsLower([]rune(hostname)[0]) {
+		r, _ := utf8.DecodeRuneInString(hostname)
+		if hostname == "" || !unicode.IsLower(r) {
 			config.Runner.Name = fmt.Sprintf("runner-%s", hostname)
 		} else {
 			config.Runner.Name = hostname

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
+	"unicode"
 
 	"github.com/drone-runners/drone-runner-aws/types"
 
@@ -396,7 +398,13 @@ func FromEnviron() (EnvConfig, error) {
 		config.Runner.Environ = map[string]string{}
 	}
 	if config.Runner.Name == "" {
-		config.Runner.Name, _ = os.Hostname()
+		hostname, _ := os.Hostname()
+		hostname = strings.ToLower(hostname)
+		if hostname == "" || !unicode.IsLower([]rune(hostname)[0]) {
+			config.Runner.Name = fmt.Sprintf("runner-%s", hostname)
+		} else {
+			config.Runner.Name = hostname
+		}
 	}
 	if config.Dashboard.Password == "" {
 		config.Dashboard.Disabled = true

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -400,6 +400,7 @@ func FromEnviron() (EnvConfig, error) {
 	}
 	if config.Runner.Name == "" {
 		hostname, _ := os.Hostname()
+		// check if first character in hostname is lowercase
 		hostname = strings.ToLower(hostname)
 		r, size := utf8.DecodeRuneInString(hostname)
 		if !(size > 0 && unicode.IsLower(r)) {

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -401,8 +401,8 @@ func FromEnviron() (EnvConfig, error) {
 	if config.Runner.Name == "" {
 		hostname, _ := os.Hostname()
 		hostname = strings.ToLower(hostname)
-		r, _ := utf8.DecodeRuneInString(hostname)
-		if hostname == "" || !unicode.IsLower(r) {
+		r, size := utf8.DecodeRuneInString(hostname)
+		if !(size > 0 && unicode.IsLower(r)) {
 			config.Runner.Name = fmt.Sprintf("runner-%s", hostname)
 		} else {
 			config.Runner.Name = hostname


### PR DESCRIPTION
If the hostname starts with a number (example `0b68be1f3feb`), GCP API call fails with the below error
`googleapi: Error 400: Invalid value for field 'resource.name': '0b68be1f3feb-ubuntu-gcp-pgfir7t8-t0n4f'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'`

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
