### PR TITLE
[CI-9078]: Added envman binary in cloudinit

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -126,6 +126,8 @@ wget -nv https://github.com/harness/tmate/releases/download/1.0/tmate-1.0-static
 tar -xf /addon/tmate.xz -C /addon/
 chmod 777  /addon/tmate-1.0-static-linux-amd64/tmate
 mv  /addon/tmate-1.0-static-linux-amd64/tmate /addon/tmate
+curl -fL https://github.com/bitrise-io/envman/releases/download/2.4.2/envman-Linux-x86_64 > /usr/bin/envman
+chmod 777 /usr/bin/envman
 {{ else if eq .Platform.Arch "arm64" }}
 wget -nv https://github.com/harness/tmate/releases/download/1.0/tmate-1.0-static-linux-arm64v8.tar.xz -O /addon/tmate.xz
 tar -xf /addon/tmate.xz -C /addon/
@@ -187,6 +189,9 @@ echo "SKIP_PREPARE_SERVER=true" >> .env;
 wget {{ .PluginBinaryURI }}/plugin-{{ .Platform.OS }}-{{ .Platform.Arch }}  -O /usr/local/bin/plugin
 chmod 777 /usr/local/bin/plugin
 {{ end }}
+
+curl -fL https://github.com/bitrise-io/envman/releases/download/2.4.2/envman-Darwin-arm64 > /usr/local/bin/envman
+chmod 777 /usr/local/bin/envman
 
 /opt/homebrew/bin/lite-engine server --env-file $HOME/.env > $HOME/lite-engine.log 2>&1 &
 `
@@ -307,6 +312,8 @@ runcmd:
 - 'chmod 777  /addon/tmate-1.0-static-linux-amd64/tmate'
 - 'mv  /addon/tmate-1.0-static-linux-amd64/tmate /addon/tmate'
 - 'rm -rf /addon/tmate-1.0-static-linux-amd64/'
+- 'curl -fL https://github.com/bitrise-io/envman/releases/download/2.4.2/envman-Linux-x86_64 > /usr/bin/envman'
+- 'chmod 777 /usr/bin/envman'
 {{ else if eq .Platform.Arch "arm64" }}
 - 'wget -nv https://github.com/harness/tmate/releases/download/1.0/tmate-1.0-static-linux-arm64v8.tar.xz -O /addon/tmate.xz' 
 - 'tar -xf /addon/tmate.xz -C /addon/'
@@ -359,6 +366,8 @@ runcmd:
 - 'chmod 777  /addon/tmate-1.0-static-linux-amd64/tmate'
 - 'mv  /addon/tmate-1.0-static-linux-amd64/tmate /addon/tmate'
 - 'rm -rf /addon/tmate-1.0-static-linux-amd64/'
+- 'curl -fL https://github.com/bitrise-io/envman/releases/download/2.4.2/envman-Linux-x86_64 > /usr/bin/envman'
+- 'chmod 777 /usr/bin/envman'
 {{ else if eq .Platform.Arch "arm64" }}
 - 'wget https://github.com/harness/tmate/releases/download/1.0/tmate-1.0-static-linux-arm64v8.tar.xz -O /addon/tmate.xz' 
 - 'tar -xf /addon/tmate.xz -C /addon/'


### PR DESCRIPTION
Added envman binary in cloudinit. This binary is used by bitrise plugins to support output variables.
