### PR TITLE
Fix default cloudinit for non-linux pools

### DIFF
--- a/internal/lehelper/lehelper.go
+++ b/internal/lehelper/lehelper.go
@@ -29,9 +29,9 @@ func GenerateUserdata(userdata string, opts *types.InstanceCreateOpts) string {
 	}
 
 	if userdata == "" {
-		if opts.OS == oshelp.OSWindows {
+		if opts.Platform.OS == oshelp.OSWindows {
 			userdata = cloudinit.Windows(&params)
-		} else if opts.OS == oshelp.OSMac {
+		} else if opts.Platform.OS == oshelp.OSMac {
 			userdata = cloudinit.Mac(&params)
 		} else {
 			userdata = cloudinit.Linux(&params)


### PR DESCRIPTION
Without a custom cloudinit a Windows pool was attempting to start with the linux cloudinit. Check `opts.Platform.OS` not `opts.OS` to get the type.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
