### PR TITLE
add timeout for gcp zone operation get

### DIFF
--- a/internal/drivers/google/driver.go
+++ b/internal/drivers/google/driver.go
@@ -545,10 +545,10 @@ func (p *config) waitZoneOperation(ctx context.Context, name, zone string) error
 			return ctx.Err()
 		default:
 		}
-		ctx_gcp, cancel := context.WithTimeout(ctx, operationGetTimeout*time.Second)
-		defer cancel()
+		ctxGcp, cancel := context.WithTimeout(ctx, operationGetTimeout*time.Second)
 		client := p.service
-		op, err := client.ZoneOperations.Get(p.projectID, zone, name).Context(ctx_gcp).Do()
+		op, err := client.ZoneOperations.Get(p.projectID, zone, name).Context(ctxGcp).Do()
+		cancel()
 		if err != nil {
 			if gerr, ok := err.(*googleapi.Error); ok &&
 				gerr.Code == http.StatusNotFound {


### PR DESCRIPTION
We saw some executions where the gcp zone operation get call is getting stuck for default timeout (10m). Have added smaller timeout on that api call so that it can retry again.