### PR TITLE
feat: [CI-11955]: Updated windows cloud init

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -451,7 +451,7 @@ func Linux(params *Params) (payload string) {
 
 const windowsScript = `
 <powershell>
-
+$ProgressPreference = 'SilentlyContinue'
 echo "[DRONE] Initialization Starting"
 
 echo "[DRONE] Installing Scoop Package Manager"


### PR DESCRIPTION
# Commit Checklist
Progressbar significantly increases the download time during cloud init. This pr disables it. I have noticed that it helps reducing overall cloud init time by 120+ seconds 

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
