### PR TITLE
fix: [CI-11955]: add https to scoop script

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -455,7 +455,7 @@ $ProgressPreference = 'SilentlyContinue'
 echo "[DRONE] Initialization Starting"
 
 echo "[DRONE] Installing Scoop Package Manager"
-iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+iex "& {$(irm https://get.scoop.sh)} -RunAsAdmin"
 
 echo "[DRONE] Installing Git"
 scoop install git --global


### PR DESCRIPTION
Why this change?
> Customer has a restriction that they can only access https urls.

Wouldn't it break for already existing customers who donot have https connectivity?
> For downloading le and plugin we use https only, it would have never worked for them in the first place.

Tested for both aws and gcp windows vms.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
