### PR TITLE
fix distributed purger to use same pool 

### DIFF
--- a/internal/drivers/distributed_manager.go
+++ b/internal/drivers/distributed_manager.go
@@ -126,6 +126,7 @@ func (d *DistributedManager) startInstancePurger(ctx context.Context, pool *pool
 
 	if maxAgeBusy != 0 {
 		busyCondition := squirrel.And{
+			squirrel.Eq{"instance_pool": pool.Name},
 			squirrel.Eq{"instance_state": types.StateInUse},
 			squirrel.Lt{"instance_started": currentTime.Add(-maxAgeBusy).Unix()},
 		}

--- a/internal/drivers/manager.go
+++ b/internal/drivers/manager.go
@@ -351,6 +351,11 @@ func (m *Manager) Provision(ctx context.Context, poolName, runnerName, serverNam
 	inst := free[0]
 	inst.State = types.StateInUse
 	inst.OwnerID = ownerID
+	if inst.IsHibernated {
+		// update started time after bringing instance from hibernate
+		// this will make sure that purger only picks it when it is actually used for max age
+		inst.Started = time.Now().Unix()
+	}
 	err = m.instanceStore.Update(ctx, inst)
 	if err != nil {
 		pool.Unlock()

--- a/store/database/migrate/postgres/0008_create_index_instances_pool_state_started_at.up.sql
+++ b/store/database/migrate/postgres/0008_create_index_instances_pool_state_started_at.up.sql
@@ -1,0 +1,3 @@
+-- Uses btree to create index
+-- Need this for purger
+CREATE INDEX IF NOT EXISTS INSTANCE_POOL_STATE_STARTED_INDEX ON instances(instance_pool, instance_state, instance_started);

--- a/store/database/sql/instances.go
+++ b/store/database/sql/instances.go
@@ -229,5 +229,6 @@ SET
  ,is_hibernated 	= :is_hibernated
  ,instance_address  = :instance_address
  ,instance_owner_id = :instance_owner_id
+ ,instance_started  = :instance_started
 WHERE instance_id   = :instance_id
 `


### PR DESCRIPTION
Fixed following things with this PR:
1. We were not using the instance_pool field to filter for the pool for which purger was running. Due to this for any other pool too we would have fetched the VM from DB but eventually it will fail since driver won't match for it.
2. When we bring up a VM from hibernate then we don't update instance_started due to which there are chances that purger can pick it up since a VM can be in hibernate for a very long time as well.
