### PR TITLE
feat: [CI-11955]: removed scoop from dlite windows cloudinit

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -454,14 +454,16 @@ const windowsScript = `
 $ProgressPreference = 'SilentlyContinue'
 echo "[DRONE] Initialization Starting"
 
-echo "[DRONE] Installing Scoop Package Manager"
-iex "& {$(irm https://get.scoop.sh)} -RunAsAdmin"
+if (${{ .IsHosted }} -eq $false) {
+	echo "[DRONE] Installing Scoop Package Manager"
+	iex "& {$(irm https://get.scoop.sh)} -RunAsAdmin"
 
-echo "[DRONE] Installing Git"
-scoop install git --global
+	echo "[DRONE] Installing Git"
+	scoop install git --global
 
-echo "[DRONE] Updating PATH so we have access to git commands (otherwise Scoop.sh shim files cannot be found)"
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+	echo "[DRONE] Updating PATH so we have access to git commands (otherwise Scoop.sh shim files cannot be found)"
+	$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+}
 
 echo "[DRONE] Setup LiteEngine Certificates"
 
@@ -479,13 +481,6 @@ $Object = [System.Convert]::FromBase64String($object1)
 $object2 = "{{ .TLSKey | base64 }}"
 $Object = [System.Convert]::FromBase64String($object2)
 [system.io.file]::WriteAllBytes("{{ .KeyPath }}",$object)
-
-# create powershell profile
-
-if (test-path($profile) -eq "false")
-{
-	new-item -path $env:windir\System32\WindowsPowerShell\v1.0\profile.ps1 -itemtype file -force
-}
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls
 


### PR DESCRIPTION
Git comes already installed with hosted vms image, hence put a if condition to not do it for hosted.
The default git version on vms is 2.42.0.windows.2 while scoop installs 2.44.0.windows.1. No major changes between these two.
Removed a condition in script that was always failing and taking some time due to syntax error.
Tested on aws and gcp.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
