### PR TITLE
[fix]: [CI-12562]: lite-engine upgrade

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -336,7 +336,7 @@ type EnvConfig struct {
 		PurgerTime           int64  `envconfig:"DRONE_PURGER_TIME_MINUTES" default:"30"`
 	}
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.68/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.70/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.69
+	github.com/harness/lite-engine v0.5.70
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.69 h1:0Uyh0CUmqWmHnqIyoGMLXlXECoRGOEC6RlFihY7XIfU=
-github.com/harness/lite-engine v0.5.69/go.mod h1:r9Hbz0rdJ3STJvrekSnOTxp11Ab4eaP5ZMruUq+giRc=
+github.com/harness/lite-engine v0.5.70 h1:VZUm5zdnsLNTfH/ckXZvHXpT/t0DBneLR52PEo+zwwU=
+github.com/harness/lite-engine v0.5.70/go.mod h1:r9Hbz0rdJ3STJvrekSnOTxp11Ab4eaP5ZMruUq+giRc=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=


### PR DESCRIPTION
Lite engine version upgrade to 0.5.70.
This version consists of changes for supporting output variables as secrets for plugins to export 

