### PR TITLE
fix: [CI-11826]: Added support Azure VM spin up for custom image

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -144,6 +144,7 @@ type (
 		Zones             []string          `json:"zones,omitempty" yaml:"zones,omitempty"`
 		Tags              map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
 		SecurityGroupName string            `json:"security_group_name,omitempty" yaml:"security_group_name,omitempty"`
+		SecurityType      string            `json:"security_type,omitempty" yaml:"security_type,omitempty"`
 	}
 
 	AzureAccount struct {

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -160,6 +160,7 @@ type (
 		Version   string `json:"version,omitempty"  yaml:"version,omitempty"`
 		Username  string `json:"username,omitempty"  yaml:"username,omitempty"`
 		Password  string `json:"password,omitempty"  yaml:"password,omitempty"`
+		ID        string `json:"id,omitempty"  yaml:"id,omitempty"`
 	}
 
 	// DigitalOcean specifies the configuration for a DigitalOcean instance.

--- a/internal/drivers/azure/driver.go
+++ b/internal/drivers/azure/driver.go
@@ -171,7 +171,7 @@ func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 
 	logr.Traceln("azure: creating VM")
 	var imageReference *armcompute.ImageReference
-	if c.publisher == "" || c.offer == "" || c.sku == "" || c.version == "" {
+	if c.ID != "" {
 		imageReference = &armcompute.ImageReference{
 			ID: to.Ptr(c.ID),
 		}

--- a/internal/drivers/azure/driver.go
+++ b/internal/drivers/azure/driver.go
@@ -31,7 +31,7 @@ type config struct {
 	securityGroupName string
 
 	rootDir      string
-	ID           string
+	id           string
 	securityType string
 
 	location string // region, example: East US
@@ -172,9 +172,9 @@ func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 
 	logr.Traceln("azure: creating VM")
 	var imageReference *armcompute.ImageReference
-	if c.ID != "" {
+	if c.id != "" {
 		imageReference = &armcompute.ImageReference{
-			ID: to.Ptr(c.ID),
+			ID: to.Ptr(c.id),
 		}
 	} else {
 		imageReference = &armcompute.ImageReference{
@@ -221,7 +221,7 @@ func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		},
 	}
 
-	if c.ID != "" {
+	if c.id != "" {
 		securityProfile := &armcompute.SecurityProfile{
 			SecurityType: (*armcompute.SecurityTypes)(&c.securityType),
 		}

--- a/internal/drivers/azure/driver.go
+++ b/internal/drivers/azure/driver.go
@@ -30,8 +30,9 @@ type config struct {
 
 	securityGroupName string
 
-	rootDir string
-	ID      string
+	rootDir      string
+	ID           string
+	securityType string
 
 	location string // region, example: East US
 
@@ -183,7 +184,8 @@ func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 			Version:   to.Ptr(c.version),
 		}
 	}
-	in := armcompute.VirtualMachine{
+
+	var in = armcompute.VirtualMachine{
 		Location: to.Ptr(c.location),
 		Zones:    c.zones,
 		Tags:     tags,
@@ -217,6 +219,13 @@ func (c *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 				},
 			},
 		},
+	}
+
+	if c.ID != "" {
+		securityProfile := &armcompute.SecurityProfile{
+			SecurityType: (*armcompute.SecurityTypes)(&c.securityType),
+		}
+		in.Properties.SecurityProfile = securityProfile
 	}
 
 	poller, err := c.service.BeginCreateOrUpdate(ctx, c.resourceGroupName, name, in, nil)

--- a/internal/drivers/azure/option.go
+++ b/internal/drivers/azure/option.go
@@ -95,6 +95,12 @@ func WithId(id string) Option {
 	}
 }
 
+func WithSecurityType(securityType string) Option {
+	return func(p *config) {
+		p.securityType = securityType
+	}
+}
+
 func WithUsername(username string) Option {
 	return func(p *config) {
 		p.username = username

--- a/internal/drivers/azure/option.go
+++ b/internal/drivers/azure/option.go
@@ -88,6 +88,13 @@ func WithImage(publisher, offer, sku, version string) Option {
 		p.version = version
 	}
 }
+
+func WithId(id string) Option {
+	return func(p *config) {
+		p.ID = id
+	}
+}
+
 func WithUsername(username string) Option {
 	return func(p *config) {
 		p.username = username

--- a/internal/drivers/azure/option.go
+++ b/internal/drivers/azure/option.go
@@ -91,7 +91,7 @@ func WithImage(publisher, offer, sku, version string) Option {
 
 func WithId(id string) Option {
 	return func(p *config) {
-		p.ID = id
+		p.id = id
 	}
 }
 

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -138,6 +138,7 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string) ([]drivers.Pool, 
 				azure.WithZones(az.Zones...),
 				azure.WithTags(az.Tags),
 				azure.WithSecurityGroupName(az.SecurityGroupName),
+				azure.WithId(az.Image.ID),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create %s pool '%s': %v", instance.Type, instance.Name, err)

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -139,6 +139,7 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string) ([]drivers.Pool, 
 				azure.WithTags(az.Tags),
 				azure.WithSecurityGroupName(az.SecurityGroupName),
 				azure.WithId(az.Image.ID),
+				azure.WithSecurityType(az.SecurityType),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create %s pool '%s': %v", instance.Type, instance.Name, err)


### PR DESCRIPTION
## Description

We are supporting spinning up of Azure VM with custom image via pool.yml, initially it was supported for marketplace image only. 

Cases Tested
1. Keep the yaml as same as old one (backward compatibility ensured). VM was spinned up. (Image used here was market price image)
2. Changed the yaml by removing the parameters like sku, version, publisher, offer (generally used for market price image) and introduced new parameter "id" which is the full path of custom image. 
3. Trying to fill the parameters like sku, version, publisher, offer with custom image params, it will not work as it is not published image. Those params we won't find in VM spinned up custom image (By looking json response of VM)

