### PR TITLE
fix: [CI-13052]: take anka authtoken from env

### DIFF
--- a/command/compile.go
+++ b/command/compile.go
@@ -88,8 +88,8 @@ func (c *compileCommand) run(*kingpin.ParseContext) error {
 			Errorln("compile: unable to parse pool file")
 		return err
 	}
-
-	pools, err := poolfile.ProcessPool(poolFile, runnerName)
+	configEnv, err := config.FromEnviron()
+	pools, err := poolfile.ProcessPool(poolFile, runnerName, &configEnv)
 	if err != nil {
 		logrus.WithError(err).
 			Errorln("compile: unable to process pool file")

--- a/command/daemon/daemon.go
+++ b/command/daemon/daemon.go
@@ -111,7 +111,7 @@ func (c *daemonCommand) run(*kingpin.ParseContext) error {
 	}
 
 	logrus.Infoln(fmt.Sprintf("daemon: processing config for %s", env.Runner.Name))
-	pools, err := poolfile.ProcessPool(configPool, env.Runner.Name)
+	pools, err := poolfile.ProcessPool(configPool, env.Runner.Name, &env)
 	if err != nil {
 		logrus.WithError(err).
 			Fatalln("daemon: unable to process pool file")

--- a/command/exec.go
+++ b/command/exec.go
@@ -125,7 +125,7 @@ func (c *execCommand) run(*kingpin.ParseContext) error { //nolint:gocyclo // its
 			Fatalln("exec: unable to load pool file, or use an in memory pool file")
 	}
 
-	pools, err := poolfile.ProcessPool(configPool, runnerName)
+	pools, err := poolfile.ProcessPool(configPool, runnerName, &envConfig)
 	if err != nil {
 		logrus.WithError(err).
 			Errorln("exec: unable to process pool file")

--- a/command/harness/pool.go
+++ b/command/harness/pool.go
@@ -16,7 +16,7 @@ func SetupPool(ctx context.Context, env *config.EnvConfig, poolManager drivers.I
 		logrus.WithError(confErr).Fatalln("Unable to load pool file, or use an in memory pool")
 	}
 
-	pools, err := poolfile.ProcessPool(configPool, env.Runner.Name)
+	pools, err := poolfile.ProcessPool(configPool, env.Runner.Name, env)
 	if err != nil {
 		logrus.WithError(err).Errorln("unable to process pool file")
 		return configPool, err

--- a/command/setup/setup.go
+++ b/command/setup/setup.go
@@ -143,7 +143,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 			Fatalln("Unable to load pool file, or use an in memory pool")
 	}
 	// process the pool file
-	pools, processErr := poolfile.ProcessPool(configPool, runnerName)
+	pools, processErr := poolfile.ProcessPool(configPool, runnerName, &env)
 	if processErr != nil {
 		logrus.WithError(processErr).
 			Fatalln("setup: unable to process pool file")

--- a/engine/compiler/compiler_test.go
+++ b/engine/compiler/compiler_test.go
@@ -184,7 +184,7 @@ func testCompile(t *testing.T, source, golden string) *engine.Spec {
 		return nil
 	}
 
-	pools, err := poolfile.ProcessPool(poolFile, "runner")
+	pools, err := poolfile.ProcessPool(poolFile, "runner", nil)
 	if err != nil {
 		t.Errorf("unable to process pool file: %s", err)
 		return nil

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -28,7 +28,7 @@ const (
 	DefaultPoolName = "testpool"
 )
 
-func ProcessPool(poolFile *config.PoolFile, runnerName string) ([]drivers.Pool, error) { //nolint
+func ProcessPool(poolFile *config.PoolFile, runnerName string, env *config.EnvConfig) ([]drivers.Pool, error) { //nolint
 	var pools = []drivers.Pool{}
 
 	for i := range poolFile.Instances {
@@ -240,6 +240,9 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string) ([]drivers.Pool, 
 			pools = append(pools, pool)
 		case string(types.AnkaBuild):
 			var ankaBuild, ok = instance.Spec.(*config.AnkaBuild)
+			if ankaBuild.AuthToken == "" && env.AnkaBuild.Token != "" {
+				ankaBuild.AuthToken = env.AnkaBuild.Token
+			}
 			if !ok {
 				return nil, fmt.Errorf("%s pool parsing failed", instance.Name)
 			}


### PR DESCRIPTION
# Commit Checklist
We need to pick this password from env var, currently it is being set in pool yaml only and it's value is visible in gcp pod yaml. With this change, we can delete the value from pool yaml and set it as env variable(ANKA_BUILD_TOKEN) instead, which we can mark as secret.

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
