### PR TITLE
feat(aws): Add option for requiring Instance Metadata Service v2

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -50,6 +50,7 @@ type (
 		RootDirectory string            `json:"root_directory,omitempty" yaml:"root_directory,omitempty"`
 		Hibernate     bool              `json:"hibernate,omitempty"`
 		User          string            `json:"user,omitempty" yaml:"user,omitempty"`
+		IMDSv2        bool              `json:"require_imdsv2,omitempty" yaml:"require_imdsv2,omitempty" default:"false"`
 	}
 
 	AmazonAccount struct {

--- a/internal/drivers/amazon/driver.go
+++ b/internal/drivers/amazon/driver.go
@@ -54,6 +54,7 @@ type config struct {
 	iamProfileArn string
 	tags          map[string]string // user defined tags
 	hibernate     bool
+	imdsv2        bool
 
 	service *ec2.EC2
 }
@@ -297,6 +298,14 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 
 		in.HibernationOptions = &ec2.HibernationOptionsRequest{
 			Configured: aws.Bool(true),
+		}
+	}
+
+	if p.imdsv2 {
+		in.MetadataOptions = &ec2.InstanceMetadataOptionsRequest{
+			HttpEndpoint:            aws.String(ec2.InstanceMetadataEndpointStateEnabled),
+			HttpPutResponseHopLimit: aws.Int64(1),
+			HttpTokens:              aws.String(ec2.HttpTokensStateRequired),
 		}
 	}
 

--- a/internal/drivers/amazon/option.go
+++ b/internal/drivers/amazon/option.go
@@ -276,3 +276,9 @@ func WithUser(user, platform string) Option {
 		}
 	}
 }
+
+func WithIMDSv2(imdsv2 bool) Option {
+	return func(p *config) {
+		p.imdsv2 = imdsv2
+	}
+}

--- a/internal/poolfile/config.go
+++ b/internal/poolfile/config.go
@@ -103,6 +103,7 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string, env *config.EnvCo
 				amazon.WithMarketType(a.MarketType),
 				amazon.WithTags(a.Tags),
 				amazon.WithHibernate(a.Hibernate),
+				amazon.WithIMDSv2(a.IMDSv2),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create %s pool '%s': %v", instance.Type, instance.Name, err)


### PR DESCRIPTION
Currently, the `drone-runner-aws` lacks support for requiring IMDSv2 on launched EC2 instances. This limitation potentially allows builds to access the Instance Metadata endpoint, possibly exposing sensitive information not intended for their use.

This pull request introduces functionality to allow users to require IMDSv2 for runner EC2 instances in `drone-runner-aws`. By implementing IMDSv2, we can leverage its hop limit feature to restrict Instance Metadata endpoint access to the host only, enhancing security.

In addition, this pull request maintains backward compatibility by not altering default behavior.

https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/