### PR TITLE
[feat]: [CI-13579]: Return Optimization state for Failed Restore Cache Step

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -338,7 +338,7 @@ type EnvConfig struct {
 		PurgerTime           int64  `envconfig:"DRONE_PURGER_TIME_MINUTES" default:"30"`
 	}
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.76/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.77/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/command/harness/dlite/execute.go
+++ b/command/harness/dlite/execute.go
@@ -124,5 +124,5 @@ func convert(r *api.PollStepResponse) VMTaskExecutionResponse {
 	if r.Error == "" {
 		return VMTaskExecutionResponse{CommandExecutionStatus: Success, OutputVars: r.Outputs, Artifact: r.Artifact, Outputs: r.OutputV2, OptimizationState: r.OptimizationState}
 	}
-	return VMTaskExecutionResponse{CommandExecutionStatus: Failure, ErrorMessage: r.Error}
+	return VMTaskExecutionResponse{CommandExecutionStatus: Failure, ErrorMessage: r.Error, OptimizationState: r.OptimizationState}
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.76
+	github.com/harness/lite-engine v0.5.77
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/godotenv/v3 v3.0.0 h1:1YJU9nUk4tQygHOYkm+NZ5jL9IZQ3UqyBspCqL3EMQQ=
 github.com/harness/godotenv/v3 v3.0.0/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.76 h1:JzJioZHQFa98WmO1aWFRB90s9OY6DUTC0FtRbD+23Ik=
-github.com/harness/lite-engine v0.5.76/go.mod h1:07w13fj/1efZZgY78xBo+iXuZH3BiVIx44cNZkHKPlc=
+github.com/harness/lite-engine v0.5.77 h1:poylnMlqswVQyQnFPNv11c6ffOoymDhK4nl63SjOvMY=
+github.com/harness/lite-engine v0.5.77/go.mod h1:07w13fj/1efZZgY78xBo+iXuZH3BiVIx44cNZkHKPlc=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=


### PR DESCRIPTION
# Commit Checklist

Currently optimization state is not returned for a failed step. This should be done to make sure cache intel FULL_RUN is saved since cache intel is a FULL_RUN if the restore-cache-harness step fails

Tested on local

FULL_RUN (where restore step fails)

We can see that we are returning the optimization state
<img width="1639" alt="Screenshot 2024-07-24 at 12 12 32 PM" src="https://github.com/user-attachments/assets/2148fda3-7b0a-4e8f-bc4c-97e29403a20e">
<img width="1728" alt="Screenshot 2024-07-24 at 12 15 46 PM" src="https://github.com/user-attachments/assets/293b2e51-a58a-4d6e-b71d-1b0e2a923536">

Optimized Run
<img width="1639" alt="Screenshot 2024-07-24 at 12 14 38 PM" src="https://github.com/user-attachments/assets/e9bd09d9-0e48-427c-9f9a-51dc0b7d8ab9">
<img width="1728" alt="Screenshot 2024-07-24 at 12 16 06 PM" src="https://github.com/user-attachments/assets/175d491b-e01a-4ec9-aa58-4577e54383de">



## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
