### PR TITLE
fix: [CI-14221]: fix gcp instance name issue

### DIFF
--- a/internal/drivers/google/driver.go
+++ b/internal/drivers/google/driver.go
@@ -651,7 +651,11 @@ func getInstanceName(runner, pool string) string {
 	namePrefix := strings.ReplaceAll(runner, " ", "")
 	randStr, _ := randStringRunes(randStrLen)
 	name := strings.ToLower(fmt.Sprintf("%s-%s-%s-%s", namePrefix, pool, uniuri.NewLen(8), randStr)) //nolint:gomnd
-	return substrSuffix(name, maxInstanceNameLen)
+	trimmedName := substrSuffix(name, maxInstanceNameLen)
+	if trimmedName[0] == '-' {
+		trimmedName = "d" + trimmedName[1:]
+	}
+	return trimmedName
 }
 
 func shouldRetry(err error) bool {


### PR DESCRIPTION
# Description
If trimmed name starts with a '-' character, gcp throws an error, hence replacing it with a d.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
