### PR TITLE
feat: [CDE-344]: Skip CDE VMs in the dlite instance purger with the help of labels on the instance/VM

### DIFF
--- a/internal/drivers/distributed_manager.go
+++ b/internal/drivers/distributed_manager.go
@@ -100,6 +100,13 @@ func (d *DistributedManager) StartInstancePurger(ctx context.Context, maxAgeBusy
 					logrus.Traceln("distributed dlite: Launching instance purger")
 
 					queryParams := types.QueryParams{MatchLabels: map[string]string{"retain": "false"}}
+					// All instances are labeled with retain: true/false
+					// If retain is true, instance is not cleaned up while we clean the pools or run the instance purger
+					// These instances are only cleaned up when there's a cleanup request from client explicitly.
+					// This is the case for VMs created for CDE
+					// If retain is false, the instance is cleaned up as earlier. This is the case for CI VMs
+					// MatchLabels in the query params are used in a generic manner to match it against the labels stored in the instance
+					// This is similar to how K8s matchLabels and labels work.
 					for _, pool := range d.poolMap {
 						if err := d.startInstancePurger(ctx, pool, maxAgeBusy, queryParams); err != nil {
 							logger.FromContext(ctx).WithError(err).

--- a/internal/drivers/manager.go
+++ b/internal/drivers/manager.go
@@ -566,7 +566,16 @@ func (m *Manager) buildPoolWithMutex(ctx context.Context, pool *poolEntry, tlsSe
 	return m.buildPool(ctx, pool, tlsServerName, query)
 }
 
-func (m *Manager) setupInstance(ctx context.Context, pool *poolEntry, tlsServerName, ownerID, resourceClass string, inuse bool, agentConfig *types.GitspaceAgentConfig, storageConfig *types.StorageConfig) (*types.Instance, error) {
+func (m *Manager) setupInstance(
+	ctx context.Context,
+	pool *poolEntry,
+	tlsServerName,
+	ownerID,
+	resourceClass string,
+	inuse bool,
+	agentConfig *types.GitspaceAgentConfig,
+	storageConfig *types.StorageConfig,
+) (*types.Instance, error) {
 	var inst *types.Instance
 	retain := "false"
 

--- a/internal/drivers/manager.go
+++ b/internal/drivers/manager.go
@@ -252,7 +252,8 @@ func (m *Manager) StartInstancePurger(ctx context.Context, maxAgeBusy, maxAgeFre
 							pool.Lock()
 							defer pool.Unlock()
 
-							busy, free, hibernating, err := m.List(ctx, pool, nil)
+							queryParams := &types.QueryParams{MatchLabels: map[string]string{"retain": "false"}}
+							busy, free, hibernating, err := m.List(ctx, pool, queryParams)
 							if err != nil {
 								return fmt.Errorf("failed to list instances of pool=%q error: %w", pool.Name, err)
 							}
@@ -567,6 +568,7 @@ func (m *Manager) buildPoolWithMutex(ctx context.Context, pool *poolEntry, tlsSe
 
 func (m *Manager) setupInstance(ctx context.Context, pool *poolEntry, tlsServerName, ownerID, resourceClass string, inuse bool, agentConfig *types.GitspaceAgentConfig, storageConfig *types.StorageConfig) (*types.Instance, error) {
 	var inst *types.Instance
+	retain := "false"
 
 	// generate certs
 	createOptions, err := certs.Generate(m.runnerName, tlsServerName)
@@ -589,13 +591,15 @@ func (m *Manager) setupInstance(ctx context.Context, pool *poolEntry, tlsServerN
 		}
 	}
 	createOptions.AutoInjectionBinaryURI = m.autoInjectionBinaryURI
-	if agentConfig != nil {
+	if agentConfig != nil && agentConfig.Secret != "" {
 		createOptions.GitspaceOpts = types.GitspaceOpts{
 			Secret:      agentConfig.Secret,
 			AccessToken: agentConfig.AccessToken,
 			Ports:       agentConfig.Ports,
 		}
+		retain = "true"
 	}
+	createOptions.Labels = map[string]string{"retain": retain}
 	if err != nil {
 		logrus.WithError(err).
 			Errorln("manager: failed to generate certificates")

--- a/internal/drivers/nomad/driver.go
+++ b/internal/drivers/nomad/driver.go
@@ -494,8 +494,9 @@ func (p *config) destroyJob(ctx context.Context, vm, nodeID, storageIdentifier s
 		},
 	}
 	if storageIdentifier != "" {
-		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, p.getCephStorageScriptCreateTask(cephStorageScriptEncoded, cephStorageScriptPath))
-		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, p.getCephStorageScriptCleanupTask(cephStorageScriptPath))
+		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks,
+			p.getCephStorageScriptCreateTask(cephStorageScriptEncoded, cephStorageScriptPath),
+			p.getCephStorageScriptCleanupTask(cephStorageScriptPath))
 	}
 	return job, id
 }
@@ -510,6 +511,7 @@ func cleanupStorage(vm string, storageIdentifier string, storageCleanupType *sto
 
 	sb := &strings.Builder{}
 	storageIdentifierSplit := strings.Split(storageIdentifier, "/")
+	//nolint:gomnd
 	if len(storageIdentifierSplit) != 2 {
 		return "", "", fmt.Errorf("scheduler: could not parse storage identifier %s", storageIdentifier)
 	}
@@ -681,7 +683,7 @@ func (p *config) getCephStorageScriptCleanupTask(deProvisionCephStorageScriptPat
 	}
 }
 
-func (p *config) getCephStorageScriptCreateTask(cephStorageScriptEncoded string, cephStorageScriptPath string) *api.Task {
+func (p *config) getCephStorageScriptCreateTask(cephStorageScriptEncoded, cephStorageScriptPath string) *api.Task {
 	return &api.Task{
 		Name:      "create_ceph_storage_cleanup_script_on_host",
 		Driver:    "raw_exec",

--- a/internal/drivers/nomad/driver.go
+++ b/internal/drivers/nomad/driver.go
@@ -501,7 +501,7 @@ func (p *config) destroyJob(ctx context.Context, vm, nodeID, storageIdentifier s
 	return job, id
 }
 
-func cleanupStorage(vm string, storageIdentifier string, storageCleanupType *storage.CleanupType, destroyCmd *string) (string, string, error) {
+func cleanupStorage(vm, storageIdentifier string, storageCleanupType *storage.CleanupType, destroyCmd *string) (string, string, error) {
 	var cephStorageCleanupScriptTemplate *template.Template
 	if *storageCleanupType == storage.Detach {
 		cephStorageCleanupScriptTemplate = template.Must(template.New("detach-ceph-storage").Funcs(funcs).Parse(detachCephStorageScript))

--- a/internal/drivers/nomad/driver.go
+++ b/internal/drivers/nomad/driver.go
@@ -501,7 +501,7 @@ func (p *config) destroyJob(ctx context.Context, vm, nodeID, storageIdentifier s
 	return job, id
 }
 
-func cleanupStorage(vm, storageIdentifier string, storageCleanupType *storage.CleanupType, destroyCmd *string) (cephStorageScriptEncoded string, cephStorageScriptPath string, err error) {
+func cleanupStorage(vm, storageIdentifier string, storageCleanupType *storage.CleanupType, destroyCmd *string) (cephStorageScriptEncoded, cephStorageScriptPath string, err error) {
 	var cephStorageCleanupScriptTemplate *template.Template
 	if *storageCleanupType == storage.Detach {
 		cephStorageCleanupScriptTemplate = template.Must(template.New("detach-ceph-storage").Funcs(funcs).Parse(detachCephStorageScript))

--- a/internal/drivers/nomad/linux_virtualizer.go
+++ b/internal/drivers/nomad/linux_virtualizer.go
@@ -287,7 +287,7 @@ func (lv *LinuxVirtualizer) GetDestroyScriptGenerator() func(string) string {
 	}
 }
 
-func (lv *LinuxVirtualizer) getScriptCleanupCmd(opts *types.InstanceCreateOpts, hostPath string, provisionCephStorageScriptPath string) string {
+func (lv *LinuxVirtualizer) getScriptCleanupCmd(opts *types.InstanceCreateOpts, hostPath, provisionCephStorageScriptPath string) string {
 	cleanUpCmdFormat := "rm %s"
 	cleanUpCmdArgs := []interface{}{hostPath}
 	if opts.StorageOpts.Identifier != "" && provisionCephStorageScriptPath != "" {

--- a/internal/drivers/nomad/linux_virtualizer.go
+++ b/internal/drivers/nomad/linux_virtualizer.go
@@ -45,6 +45,14 @@ func (lv *LinuxVirtualizer) GetInitJob(vm, nodeID, vmImage, userData, username, 
 	runCmdFormat = "%s run %s --name %s --cpus %s --memory %sGB --size %s --ssh --runtime=docker --ports %d:%s --copy-files %s:%s"
 	args := []interface{}{ignitePath, vmImage, vm, resource.Cpus, resource.MemoryGB, resource.DiskSize, port, strconv.Itoa(lehelper.LiteEnginePort), hostPath, vmPath}
 
+	// add labels
+	if len(opts.Labels) > 0 {
+		runCmdFormat += " --label"
+		for key, value := range opts.Labels {
+			runCmdFormat += fmt.Sprintf(" %s=%s", key, value)
+		}
+	}
+
 	// gitspace args
 	for vmPort, hostPort := range gitspacesPortMappings {
 		runCmdFormat += " --ports %d:%d"

--- a/store/database/migrate/postgres/0010_update_table_instances_labels.up.sql
+++ b/store/database/migrate/postgres/0010_update_table_instances_labels.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instances ADD COLUMN instance_labels JSONB NOT NULL DEFAULT '{"retain":"false"}';

--- a/store/database/migrate/sqlite/0008_update_table_instances_labels.up.sql
+++ b/store/database/migrate/sqlite/0008_update_table_instances_labels.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instances ADD COLUMN instance_labels JSONB NOT NULL DEFAULT '{"retain":"false"}';

--- a/store/database/sql/instances.go
+++ b/store/database/sql/instances.go
@@ -51,6 +51,11 @@ func (s InstanceStore) List(_ context.Context, pool string, params *types.QueryP
 			stmt = stmt.Where(squirrel.Eq{"runner_name": params.RunnerName})
 			args = append(args, params.RunnerName)
 		}
+		for key, value := range params.MatchLabels {
+			condition := squirrel.Expr("(instance_labels->>?) = ?", key, value)
+			stmt = stmt.Where(condition)
+			args = append(args, key, value)
+		}
 	}
 	stmt = stmt.OrderBy("instance_started " + "ASC")
 	sql, _, _ := stmt.ToSql()
@@ -149,6 +154,7 @@ const instanceColumns = `
 ,instance_port
 ,instance_owner_id
 ,instance_storage_identifier
+,instance_labels
 `
 
 const instanceFindByID = `SELECT ` + instanceColumns + `
@@ -186,6 +192,7 @@ INSERT INTO instances (
 ,instance_owner_id
 ,runner_name
 ,instance_storage_identifier
+,instance_labels
 ) values (
  :instance_id
 ,:instance_node_id
@@ -215,6 +222,7 @@ INSERT INTO instances (
 ,:instance_owner_id
 ,:runner_name
 ,:instance_storage_identifier
+,:instance_labels
 ) RETURNING instance_id
 `
 

--- a/types/types.go
+++ b/types/types.go
@@ -67,6 +67,7 @@ type Instance struct {
 	RunnerName           string      `db:"runner_name" json:"runner_name"`
 	GitspacePortMappings map[int]int `json:"gitspaces_port_mappings"`
 	StorageIdentifier    string      `db:"instance_storage_identifier" json:"storage_identifier"`
+	Labels               []byte      `db:"instance_labels" json:"instance_labels"`
 }
 
 type Tmate struct {
@@ -98,6 +99,7 @@ type InstanceCreateOpts struct {
 	GitspaceOpts           GitspaceOpts
 	StorageOpts            StorageOpts
 	AutoInjectionBinaryURI string
+	Labels                 map[string]string
 }
 
 // Platform defines the target platform.
@@ -110,10 +112,11 @@ type Platform struct {
 }
 
 type QueryParams struct {
-	Status     InstanceState
-	Stage      string
-	Platform   *Platform
-	RunnerName string
+	Status      InstanceState
+	Stage       string
+	Platform    *Platform
+	RunnerName  string
+	MatchLabels map[string]string
 }
 
 type StageOwner struct {


### PR DESCRIPTION
1. Storing labels in the instance table as well as setting them in the VM in the ignite run command
2. Added migration to add this column with default {"retain":"false"}
3. CI instances/VMs will have {"retain":"false"} label
4. CDE instances/VMs will have {"retain":"false"} label
5. The list instance query from the purger would have {"retain":"false"} matchlabels to match only CI instances and avoid cleanup of CDE instances/VMs

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
