### PR TITLE
feat: [CDE-365]: Send the whole gitspace agent script instead of individual params

### DIFF
--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -250,6 +250,20 @@ echo "done starting lite engine server"
 {{ if .GitspaceAgentConfig.VMInitScript }}
 {{ .GitspaceAgentConfig.VMInitScript }}
 {{ else }}
+groupadd docker
+mkdir -p /opt/gitspaceagent
+
+echo "Updating docker root dir"
+systemctl stop docker
+mkdir -p /mnt/disks/mountdevcontainer/docker
+tee /etc/docker/daemon.json <<EOF
+{
+  "data-root": "/mnt/disks/mountdevcontainer/docker"
+}
+EOF
+systemctl start docker
+echo "Successfully updated docker root dir"
+
 echo "downloading gitspaces agent binary"
 echo HARNESS_JWT_SECRET={{ .GitspaceAgentConfig.Secret }} >> /etc/profile
 export HARNESS_JWT_SECRET={{ .GitspaceAgentConfig.Secret }}

--- a/internal/cloudinit/cloudinit.go
+++ b/internal/cloudinit/cloudinit.go
@@ -388,8 +388,8 @@ func LinuxBash(params *Params) (payload string) {
 	if (params.GitspaceAgentConfig.Secret != "" && params.GitspaceAgentConfig.AccessToken != "") ||
 		(params.GitspaceAgentConfig.VMInitScript != "") {
 		if params.GitspaceAgentConfig.VMInitScript != "" {
-			decodedScript, err := base64.StdEncoding.DecodeString(params.GitspaceAgentConfig.VMInitScript)
-			if err != nil {
+			decodedScript, decodeErr := base64.StdEncoding.DecodeString(params.GitspaceAgentConfig.VMInitScript)
+			if decodeErr != nil {
 				err = fmt.Errorf("failed to decode the gitspaces vm init script: %w", err)
 				panic(err)
 			}

--- a/internal/drivers/manager.go
+++ b/internal/drivers/manager.go
@@ -601,11 +601,12 @@ func (m *Manager) setupInstance(
 		}
 	}
 	createOptions.AutoInjectionBinaryURI = m.autoInjectionBinaryURI
-	if agentConfig != nil && agentConfig.Secret != "" {
+	if agentConfig != nil && (agentConfig.Secret != "" || agentConfig.VMInitScript != "") {
 		createOptions.GitspaceOpts = types.GitspaceOpts{
-			Secret:      agentConfig.Secret,
-			AccessToken: agentConfig.AccessToken,
-			Ports:       agentConfig.Ports,
+			Secret:       agentConfig.Secret,
+			AccessToken:  agentConfig.AccessToken,
+			Ports:        agentConfig.Ports,
+			VMInitScript: agentConfig.VMInitScript,
 		}
 		retain = "true"
 	}

--- a/internal/drivers/nomad/linux_virtualizer.go
+++ b/internal/drivers/nomad/linux_virtualizer.go
@@ -227,8 +227,13 @@ func (lv *LinuxVirtualizer) generateUserData(opts *types.InstanceCreateOpts) str
 		Tmate:                  opts.Tmate,
 		AutoInjectionBinaryURI: opts.AutoInjectionBinaryURI,
 	}
-	if opts.GitspaceOpts.Secret != "" && opts.GitspaceOpts.AccessToken != "" {
-		params.GitspaceAgentConfig = types.GitspaceAgentConfig{Secret: opts.GitspaceOpts.Secret, AccessToken: opts.GitspaceOpts.AccessToken}
+	if (opts.GitspaceOpts.Secret != "" && opts.GitspaceOpts.AccessToken != "") ||
+		(opts.GitspaceOpts.VMInitScript != "") {
+		params.GitspaceAgentConfig = types.GitspaceAgentConfig{
+			Secret:       opts.GitspaceOpts.Secret,
+			AccessToken:  opts.GitspaceOpts.AccessToken,
+			VMInitScript: opts.GitspaceOpts.VMInitScript,
+		}
 	}
 	return cloudinit.LinuxBash(params)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -125,9 +125,10 @@ type StageOwner struct {
 }
 
 type GitspaceOpts struct {
-	Secret      string
-	AccessToken string
-	Ports       []int
+	Secret       string // Deprecated: VMInitScript should be used to send the whole script
+	AccessToken  string // Deprecated: VMInitScript should be used to send the whole script
+	Ports        []int
+	VMInitScript string
 }
 
 type StorageOpts struct {
@@ -137,9 +138,10 @@ type StorageOpts struct {
 }
 
 type GitspaceAgentConfig struct {
-	Secret      string `json:"secret"`
-	AccessToken string `json:"access_token"`
-	Ports       []int  `json:"ports"`
+	Secret       string `json:"secret"`       // Deprecated: VMInitScript should be used to send the whole script
+	AccessToken  string `json:"access_token"` // Deprecated: VMInitScript should be used to send the whole script
+	Ports        []int  `json:"ports"`
+	VMInitScript string `json:"vm_init_script"`
 }
 
 type StorageConfig struct {


### PR DESCRIPTION
# Description
Since we wanted to send more params for container name, tag, image etc, instead of adding so many params, thought of sending the whole script and appending to the existing one in cloudinit.go
To keep it backward compatible, I haven't removed any existing params.
This would be the script coming from CDE Manager with all the replaced values.
```
groupadd docker
mkdir -p /mnt/disks/mountdevcontainer/gitspace
export DOCKER_API_VERSION={{ .AgentDockerAPIVersion }}

echo "Updating docker root dir"
systemctl stop docker
mkdir -p /mnt/disks/mountdevcontainer/docker
tee /etc/docker/daemon.json <<EOF
{
  "data-root": "/mnt/disks/mountdevcontainer/docker"
}
EOF
systemctl start docker
echo "Successfully updated docker root dir"

echo "starting gitspaces agent"

# Check if the container is present

if docker ps -a --filter "name={{ .AgentContainerName }}" --quiet | grep -q .; then
    echo "Container {{ .AgentContainerName }} exists. Attempting to start it..."

    # Try to start the container
    docker start {{ .AgentContainerName }}
    if [ $? -ne 0 ]; then
        echo "Failed to start {{ .AgentContainerName }}. Deleting and recreating..."
        docker rm -f {{ .AgentContainerName }}
        echo {{ .AgentContainerRegistryToken }} | docker login -u oauth2accesstoken --password-stdin {{ .AgentContainerRegistry }}
        docker run -p 8083:8083 -v /var/run/docker.sock:/var/run/docker.sock -e DOCKER_API_VERSION={{ .AgentDockerAPIVersion }} -e HARNESS_JWT_SECRET={{ .AgentSecret }} -d --name {{ .AgentContainerName }} {{ .AgentImage }}:{{ .AgentTag }}
    else
        echo "{{ .AgentContainerName }} started successfully."
    fi
else
    echo "Container {{ .AgentContainerName }} does not exist. Creating it..."
    echo {{ .AgentContainerRegistryToken }} | docker login -u oauth2accesstoken --password-stdin {{ .AgentContainerRegistry }}
    docker run -p 8083:8083 -v /var/run/docker.sock:/var/run/docker.sock -e DOCKER_API_VERSION={{ .AgentDockerAPIVersion }} -e HARNESS_JWT_SECRET={{ .AgentSecret }} -d --name {{ .AgentContainerName }} {{ .AgentImage }}:{{ .AgentTag }}
    echo "Agent container started."
fi

echo "done starting gitspaces agent"
```

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
