### PR TITLE
feat: [CI-15282] Update lite-engine version to v0.5.87

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -349,7 +349,7 @@ type EnvConfig struct {
 		AutoInjectionBinaryURI string `envconfig:"DRONE_HARNESS_AUTO_INJECTION_BINARY_URI"`
 	}
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.85/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.87/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.85
+	github.com/harness/lite-engine v0.5.87
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.85 h1:lfwQcpl/gVutdjfxSaFZT9EBaNTkMfnEIAOpoOpzuf8=
-github.com/harness/lite-engine v0.5.85/go.mod h1:CwyhOnIA6XDt/U02eKUXwT0hIMK4Q9uKG9LM86j7qns=
+github.com/harness/lite-engine v0.5.87 h1:eeVHThDHFV7s8Xrl2Nuc8zKAWIxCQtVtNQgthXaTC4g=
+github.com/harness/lite-engine v0.5.87/go.mod h1:CwyhOnIA6XDt/U02eKUXwT0hIMK4Q9uKG9LM86j7qns=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=


### PR DESCRIPTION
This updates lite-engine to 0.5.87

This is the concerned tag on lite-engine repo: https://github.com/harness/lite-engine/commits/v0.5.87/