### PR TITLE
feat: [CDE-583]: Make destroy operation stateless by passing instance details instead of relying on db / in memory storage

### DIFF
--- a/app/drivers/imanager.go
+++ b/app/drivers/imanager.go
@@ -17,8 +17,8 @@ type IManager interface {
 	Update(ctx context.Context, instance *types.Instance) error
 	Add(pools ...Pool) error
 	StartInstancePurger(ctx context.Context, maxAgeBusy, maxAgeFree time.Duration, purgerTime time.Duration) error
-	Provision(ctx context.Context, poolName, serverName, ownerID, resourceClass string, query *types.QueryParams, gitspaceAgentConfig *types.GitspaceAgentConfig, storageConfig *types.StorageConfig) (*types.Instance, error) //nolint
-	Destroy(ctx context.Context, poolName, instanceID string, storageCleanupType *storage.CleanupType) error
+	Provision(ctx context.Context, poolName, serverName, ownerID, resourceClass string, query *types.QueryParams, gitspaceAgentConfig *types.GitspaceAgentConfig, storageConfig *types.StorageConfig, zone string) (*types.Instance, error) //nolint
+	Destroy(ctx context.Context, poolName string, instanceID string, instance *types.Instance, storageCleanupType *storage.CleanupType) error
 	BuildPools(ctx context.Context) error
 	CleanPools(ctx context.Context, destroyBusy, destroyFree bool) error
 	StartInstance(ctx context.Context, poolName, instanceID string) (*types.Instance, error)

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -324,6 +324,7 @@ func (m *Manager) Provision(
 	query *types.QueryParams,
 	gitspaceAgentConfig *types.GitspaceAgentConfig,
 	storageConfig *types.StorageConfig,
+	zone string,
 ) (*types.Instance, error) { //nolint
 
 	pool := m.poolMap[poolName]
@@ -335,7 +336,7 @@ func (m *Manager) Provision(
 		if pool.Driver.DriverName() != string(types.Nomad) && pool.Driver.DriverName() != string(types.Google) {
 			return nil, fmt.Errorf("incorrect pool, gitspaces is only supported on nomad/google")
 		}
-		inst, err := m.setupInstance(ctx, pool, serverName, ownerID, resourceClass, true, gitspaceAgentConfig, storageConfig)
+		inst, err := m.setupInstance(ctx, pool, serverName, ownerID, resourceClass, true, gitspaceAgentConfig, storageConfig, zone)
 		return inst, err
 	}
 
@@ -358,7 +359,7 @@ func (m *Manager) Provision(
 			return nil, ErrorNoInstanceAvailable
 		}
 		var inst *types.Instance
-		inst, err = m.setupInstance(ctx, pool, serverName, ownerID, resourceClass, true, gitspaceAgentConfig, storageConfig)
+		inst, err = m.setupInstance(ctx, pool, serverName, ownerID, resourceClass, true, gitspaceAgentConfig, storageConfig, zone)
 		if err != nil {
 			return nil, fmt.Errorf("provision: failed to create instance: %w", err)
 		}
@@ -389,33 +390,36 @@ func (m *Manager) Provision(
 	// the go routine here uses the global context because this function is called
 	// from setup API call (and we can't use HTTP request context for async tasks)
 	go func(ctx context.Context) {
-		_, _ = m.setupInstance(ctx, pool, serverName, "", "", false, nil, nil)
+		_, _ = m.setupInstance(ctx, pool, serverName, "", "", false, nil, nil, zone)
 	}(m.globalCtx)
 
 	return inst, nil
 }
 
 // Destroy destroys an instance in a pool.
-func (m *Manager) Destroy(ctx context.Context, poolName, instanceID string, storageCleanupType *storage.CleanupType) error {
+func (m *Manager) Destroy(ctx context.Context, poolName string, instanceID string, instance *types.Instance, storageCleanupType *storage.CleanupType) error {
 	pool := m.poolMap[poolName]
 	if pool == nil {
 		return fmt.Errorf("provision: pool name %q not found", poolName)
 	}
 
-	instance, err := m.Find(ctx, instanceID)
-	if err != nil {
-		return err
+	if instance == nil {
+		instanceFromStore, err := m.Find(ctx, instanceID)
+		if err != nil || instanceFromStore == nil {
+			return fmt.Errorf("provision: failed to find instance %q: %w", instanceID, err)
+		}
+		instance = instanceFromStore
 	}
 
-	err = pool.Driver.DestroyInstanceAndStorage(ctx, []*types.Instance{instance}, storageCleanupType)
+	err := pool.Driver.DestroyInstanceAndStorage(ctx, []*types.Instance{instance}, storageCleanupType)
 	if err != nil {
 		return fmt.Errorf("provision: failed to destroy an instance of %q pool: %w", poolName, err)
 	}
 
-	if derr := m.Delete(ctx, instanceID); derr != nil {
-		logrus.Warnf("failed to delete instance %s from store with err: %s", instanceID, derr)
+	if derr := m.Delete(ctx, instance.ID); derr != nil {
+		logrus.Warnf("failed to delete instance %s from store with err: %s", instance, derr)
 	}
-	logrus.WithField("instance", instanceID).Infof("instance destroyed")
+	logrus.WithField("instance", instance.ID).Infof("instance destroyed")
 	return nil
 }
 
@@ -550,7 +554,7 @@ func (m *Manager) buildPool(ctx context.Context, pool *poolEntry, tlsServerName 
 			defer wg.Done()
 
 			// generate certs cert
-			inst, err := m.setupInstance(ctx, pool, tlsServerName, "", "", false, nil, nil)
+			inst, err := m.setupInstance(ctx, pool, tlsServerName, "", "", false, nil, nil, "")
 			if err != nil {
 				logr.WithError(err).Errorln("build pool: failed to create instance")
 				return
@@ -585,6 +589,7 @@ func (m *Manager) setupInstance(
 	inuse bool,
 	agentConfig *types.GitspaceAgentConfig,
 	storageConfig *types.StorageConfig,
+	zone string,
 ) (*types.Instance, error) {
 	var inst *types.Instance
 	retain := "false"
@@ -620,6 +625,7 @@ func (m *Manager) setupInstance(
 		retain = "true"
 	}
 	createOptions.Labels = map[string]string{"retain": retain}
+	createOptions.Zone = zone
 	if err != nil {
 		logrus.WithError(err).
 			Errorln("manager: failed to generate certificates")

--- a/command/harness/common.go
+++ b/command/harness/common.go
@@ -1,0 +1,13 @@
+package harness
+
+type InstanceInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	IPAddress string `json:"ip_address"`
+	Port      int64  `json:"port"`
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+	Provider  string `json:"provider"`
+	PoolName  string `json:"pool_name"`
+	Zone      string `json:"zone"`
+}

--- a/command/harness/delegate/delegate.go
+++ b/command/harness/delegate/delegate.go
@@ -235,10 +235,11 @@ func (c *delegateCommand) handleStep(w http.ResponseWriter, r *http.Request) {
 func (c *delegateCommand) handleDestroy(w http.ResponseWriter, r *http.Request) {
 	// TODO: Change the java object to match VmCleanupRequest
 	rs := &struct {
-		ID            string `json:"id"`
-		InstanceID    string `json:"instance_id"`
-		PoolID        string `json:"pool_id"`
-		CorrelationID string `json:"correlation_id"`
+		ID            string               `json:"id"`
+		InstanceID    string               `json:"instance_id"`
+		PoolID        string               `json:"pool_id"`
+		CorrelationID string               `json:"correlation_id"`
+		InstanceInfo  harness.InstanceInfo `json:"instance_info"`
 	}{}
 	if err := json.NewDecoder(r.Body).Decode(rs); err != nil {
 		logrus.WithError(err).Error("could not decode VM destroy request body")
@@ -247,7 +248,7 @@ func (c *delegateCommand) handleDestroy(w http.ResponseWriter, r *http.Request) 
 	}
 	logrus.Infoln("Received destroy request with taskId " + rs.CorrelationID)
 
-	req := &harness.VMCleanupRequest{PoolID: rs.PoolID, StageRuntimeID: rs.ID}
+	req := &harness.VMCleanupRequest{PoolID: rs.PoolID, StageRuntimeID: rs.ID, InstanceInfo: rs.InstanceInfo}
 	req.Context.TaskID = rs.CorrelationID
 
 	ctx := r.Context()

--- a/command/harness/dlite/init.go
+++ b/command/harness/dlite/init.go
@@ -103,6 +103,7 @@ func (t *VMInitTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 		PoolDriverUsed:        selectedPoolDriver,
 		GitspacesPortMappings: setupResp.GitspacesPortMappings,
+		InstanceInfo:          setupResp.InstanceInfo,
 	}
 	httphelper.WriteJSON(w, resp, httpOK)
 }

--- a/command/harness/dlite/response.go
+++ b/command/harness/dlite/response.go
@@ -1,6 +1,9 @@
 package dlite
 
-import "github.com/harness/lite-engine/api"
+import (
+	"github.com/drone-runners/drone-runner-aws/command/harness"
+	"github.com/harness/lite-engine/api"
+)
 
 type VMTaskExecutionResponse struct {
 	ErrorMessage           string                 `json:"error_message"`
@@ -14,6 +17,7 @@ type VMTaskExecutionResponse struct {
 	Outputs                []*api.OutputV2        `json:"outputs"`
 	OptimizationState      string                 `json:"optimization_state"`
 	GitspacesPortMappings  map[int]int            `json:"gitspaces_port_mappings"`
+	InstanceInfo           harness.InstanceInfo   `json:"instance_info"`
 }
 
 type DelegateMetaInfo struct {

--- a/command/harness/helper.go
+++ b/command/harness/helper.go
@@ -1,8 +1,12 @@
 package harness
 
 import (
+	"errors"
+	"fmt"
+	"github.com/drone-runners/drone-runner-aws/types"
 	"hash/fnv"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -34,4 +38,44 @@ func fileID(filename string) string {
 	h := fnv.New32a()
 	h.Write([]byte(filename))
 	return strings.Replace(filepath.Base(filename), ".", "-", -1) + strconv.Itoa(int(h.Sum32()))
+}
+
+// validateStruct checks if all fields of a struct are populated.
+func validateStruct(data interface{}) error {
+	v := reflect.ValueOf(data)
+
+	// Ensure the input is a struct
+	if v.Kind() != reflect.Struct {
+		return errors.New("input is not a struct")
+	}
+
+	// Iterate over the fields of the struct
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := v.Type().Field(i)
+
+		// Check for zero values
+		if reflect.DeepEqual(field.Interface(), reflect.Zero(field.Type()).Interface()) {
+			return fmt.Errorf("field %q is not populated", fieldType.Name)
+		}
+	}
+
+	return nil
+}
+
+func buildInstanceFromRequest(instanceInfo InstanceInfo) *types.Instance {
+	return &types.Instance{
+		ID:       instanceInfo.ID,
+		Name:     instanceInfo.Name,
+		Address:  instanceInfo.IPAddress,
+		Provider: types.DriverType(instanceInfo.Provider),
+		Pool:     instanceInfo.PoolName,
+		Platform: types.Platform{
+			OS:   instanceInfo.OS,
+			Arch: instanceInfo.Arch,
+		},
+		IsHibernated: false,
+		Port:         instanceInfo.Port,
+		Zone:         instanceInfo.Zone,
+	}
 }

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -36,12 +36,14 @@ type SetupVMRequest struct {
 	api.SetupRequest    `json:"setup_request"`
 	GitspaceAgentConfig types.GitspaceAgentConfig `json:"gitspace_agent_config"`
 	StorageConfig       types.StorageConfig       `json:"storage_config"`
+	Zone                string                    `json:"zone"`
 }
 
 type SetupVMResponse struct {
-	IPAddress             string      `json:"ip_address"`
-	InstanceID            string      `json:"instance_id"`
-	GitspacesPortMappings map[int]int `json:"gitspaces_port_mappings"`
+	IPAddress             string       `json:"ip_address"`
+	InstanceID            string       `json:"instance_id"`
+	GitspacesPortMappings map[int]int  `json:"gitspaces_port_mappings"`
+	InstanceInfo          InstanceInfo `json:"instance_info"`
 }
 
 var (
@@ -164,7 +166,7 @@ func HandleSetup(
 		_, findErr := s.Find(noContext, stageRuntimeID)
 		if findErr != nil {
 			if cerr := s.Create(noContext, &types.StageOwner{StageID: stageRuntimeID, PoolName: selectedPool}); cerr != nil {
-				if derr := poolManager.Destroy(noContext, selectedPool, instance.ID, nil); derr != nil {
+				if derr := poolManager.Destroy(noContext, selectedPool, instance.ID, instance, nil); derr != nil {
 					logr.WithError(derr).Errorln("failed to cleanup instance on setup failure")
 				}
 				return nil, "", fmt.Errorf("could not create stage owner entity: %w", cerr)
@@ -188,7 +190,18 @@ func HandleSetup(
 	}
 
 	metrics.BuildCount.WithLabelValues(selectedPool, instance.OS, instance.Arch, string(instance.Provider), strconv.FormatBool(poolManager.IsDistributed()), instance.Zone, owner).Inc()
-	resp := &SetupVMResponse{InstanceID: instance.ID, IPAddress: instance.Address, GitspacesPortMappings: instance.GitspacePortMappings}
+	instanceInfo := InstanceInfo{
+		ID:        instance.ID,
+		Name:      instance.Name,
+		IPAddress: instance.Address,
+		Port:      instance.Port,
+		OS:        platform.OS,
+		Arch:      platform.Arch,
+		Provider:  string(instance.Provider),
+		PoolName:  selectedPool,
+		Zone:      instance.Zone,
+	}
+	resp := &SetupVMResponse{InstanceID: instance.ID, IPAddress: instance.Address, GitspacesPortMappings: instance.GitspacePortMappings, InstanceInfo: instanceInfo}
 
 	logr.WithField("selected_pool", selectedPool).
 		WithField("ip", instance.Address).
@@ -230,7 +243,7 @@ func handleSetup(
 			RunnerName: runnerName,
 		}
 	}
-	instance, err := poolManager.Provision(ctx, pool, poolManager.GetTLSServerName(), owner, r.ResourceClass, query, &r.GitspaceAgentConfig, &r.StorageConfig)
+	instance, err := poolManager.Provision(ctx, pool, poolManager.GetTLSServerName(), owner, r.ResourceClass, query, &r.GitspaceAgentConfig, &r.StorageConfig, r.Zone)
 	if err != nil {
 		return nil, fmt.Errorf("failed to provision instance: %w", err)
 	}
@@ -276,7 +289,7 @@ func handleSetup(
 				}
 			}
 		}
-		err = poolManager.Destroy(context.Background(), pool, instanceID, nil)
+		err = poolManager.Destroy(context.Background(), pool, instance.ID, instance, nil)
 		if err != nil {
 			logr.WithError(err).Errorln("failed to cleanup instance on setup failure")
 		}

--- a/command/setup/setup.go
+++ b/command/setup/setup.go
@@ -155,7 +155,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 			Fatalln("setup: unable to add pool")
 	}
 	// provision
-	instance, provisionErr := poolManager.Provision(ctx, testPoolName, runnerName, "drone", "", nil, nil, nil)
+	instance, provisionErr := poolManager.Provision(ctx, testPoolName, runnerName, "drone", "", nil, nil, nil, "")
 	if provisionErr != nil {
 		consoleLogs, consoleErr := poolManager.InstanceLogs(ctx, testPoolName, instance.ID)
 		logrus.Infof("setup: instance logs for %s: %s", instance.ID, consoleLogs)
@@ -173,7 +173,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 	// start the instance
 	_, startErr := poolManager.StartInstance(ctx, testPoolName, instance.ID)
 	if startErr != nil {
-		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, nil)
+		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, instance, nil)
 		consoleLogs, consoleErr := poolManager.InstanceLogs(ctx, testPoolName, instance.ID)
 		logrus.Infof("setup: instance logs for %s: %s", instance.ID, consoleLogs)
 		logrus.WithError(startErr).
@@ -185,7 +185,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 	// create an LE client so we can test the instance
 	leClient, leErr := lehelper.GetClient(instance, runnerName, instance.Port, env.LiteEngine.EnableMock, env.LiteEngine.MockStepTimeoutSecs)
 	if leErr != nil {
-		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, nil)
+		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, instance, nil)
 		consoleLogs, consoleErr := poolManager.InstanceLogs(ctx, testPoolName, instance.ID)
 		logrus.Infof("setup: instance logs for %s: %s", instance.ID, consoleLogs)
 		logrus.WithError(leErr).
@@ -201,7 +201,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 
 	healthResponse, healthErr := leClient.RetryHealth(ctx, healthCheckWait, performDNSLookup)
 	if healthErr != nil {
-		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, nil)
+		cleanErr := poolManager.Destroy(ctx, testPoolName, instance.ID, instance, nil)
 		logrus.WithError(err).Errorln("failed health check with instance")
 		consoleLogs, consoleErr := poolManager.InstanceLogs(ctx, testPoolName, instance.ID)
 		logrus.Infof("setup: instance logs for %s: %s", instance.ID, consoleLogs)
@@ -215,7 +215,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 	// print the pool file
 	poolfile.PrintPoolFile(configPool)
 	// finally clean the instance
-	destroyErr := poolManager.Destroy(ctx, testPoolName, instance.ID, nil)
+	destroyErr := poolManager.Destroy(ctx, testPoolName, instance.ID, instance, nil)
 	return destroyErr
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -66,7 +66,7 @@ func (e *Engine) Setup(ctx context.Context, specv runtime.Spec) error {
 	}
 
 	// lets see if there is anything in the pool
-	instance, err := manager.Provision(ctx, poolName, e.config.Runner.Name, "drone", "", nil, nil, nil)
+	instance, err := manager.Provision(ctx, poolName, e.config.Runner.Name, "drone", "", nil, nil, nil, "")
 	if err != nil {
 		logr.WithError(err).Errorln("failed to provision an instance")
 		return err
@@ -169,7 +169,7 @@ func (e *Engine) Destroy(ctx context.Context, specv runtime.Spec) error {
 
 	logr.Infof("destroying instance %s", instanceID)
 
-	if err := poolMngr.Destroy(ctx, poolName, instanceID, nil); err != nil {
+	if err := poolMngr.Destroy(ctx, poolName, instanceID, nil, nil); err != nil {
 		logr.WithError(err).Errorln("cannot destroy the instance")
 		return err
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -107,6 +107,7 @@ type InstanceCreateOpts struct {
 	StorageOpts            StorageOpts
 	AutoInjectionBinaryURI string
 	Labels                 map[string]string
+	Zone                   string
 }
 
 // Platform defines the target platform.


### PR DESCRIPTION
# Description
- Passing zone in create/setup requests. If present, a random zone won't be selected. (CI requests will continue with random zone selection)
- This instance info is saved in the DB of cde-manager and passed in the destroy request.
- Destroy requests will fetch instances from DB only when not present in the request. (CI requests will continue to fetch )

# Testing
- CDE requests use the passed information from the destroy requests instead of relying on the instance record in DB
- CI requests continue to use the instance stored in DB in the destroy/cleanup request
<img width="674" alt="Screenshot 2025-01-21 at 12 56 23 PM" src="https://github.com/user-attachments/assets/404f03a3-2432-48e0-ae71-60c8f1193568" />


# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
