### PR TITLE
feat: [CDE-585]: Support creation and attaching of persistent disks

### DIFF
--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -371,7 +371,10 @@ func (p *config) attachPersistentDisk(
 		if err != nil {
 			return nil, err
 		}
-		operations = append(operations, op)
+		if op != nil {
+			// this means we have submitted disk creation request(s)
+			operations = append(operations, op)
+		}
 
 		// attach to instance
 		attachedDisk := &compute.AttachedDisk{

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -299,8 +299,8 @@ func (p *config) create(ctx context.Context, opts *types.InstanceCreateOpts, nam
 	if opts.StorageOpts.Identifier != "" {
 		operations, attachDiskErr := p.attachPersistentDisk(ctx, opts, in, zone)
 		if attachDiskErr != nil {
-			logr.WithError(err).Errorln("google: failed to attach persistent disk")
-			return nil, err
+			logr.WithError(attachDiskErr).Errorln("google: failed to attach persistent disk")
+			return nil, attachDiskErr
 		}
 		for _, operation := range operations {
 			if operation != nil {

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -595,11 +595,7 @@ func (p *config) resumeInstance(ctx context.Context, projectID, zone, name strin
 
 func (p *config) insertInstance(ctx context.Context, projectID, zone, requestID string, in *compute.Instance) (*compute.Operation, error) {
 	return retry(ctx, insertRetries, secSleep, func() (*compute.Operation, error) {
-		op, err := p.service.Instances.Insert(projectID, zone, in).RequestId(requestID).Context(ctx).Do()
-		if err != nil {
-			return op, err
-		}
-		return op, err
+		return p.service.Instances.Insert(projectID, zone, in).RequestId(requestID).Context(ctx).Do()
 	})
 }
 

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -469,6 +469,7 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 				logr.WithError(deleteInstanceErr).Errorln("google: failed to delete the VM")
 			}
 		}
+		err = deleteInstanceErr
 		logr.Info("google: sent delete instance request")
 
 		if storageCleanupType != nil && *storageCleanupType == storage.Delete && instance.StorageIdentifier != "" {

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -356,7 +356,7 @@ func (p *config) attachPersistentDisk(
 	var operations []*compute.Operation
 	for i, diskName := range storageIdentifiers {
 		requestID := uuid.New().String()
-		diskType := fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, diskZone, "pd-balanced")
+		diskType := fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, diskZone, opts.StorageOpts.Type)
 		diskSize, err := strconv.ParseInt(opts.StorageOpts.Size, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("Error converting string to int64: %v\n", err)

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -463,7 +463,7 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 		}
 		logr.Info("google: sent delete instance request")
 
-		if *storageCleanupType == storage.Delete && instance.StorageIdentifier != "" {
+		if storageCleanupType != nil && *storageCleanupType == storage.Delete && instance.StorageIdentifier != "" {
 			logr.Info("google: waiting for instance deletion")
 			err = p.waitZoneOperation(ctx, instanceDeleteOperation.Name, zone)
 			if err != nil {

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -463,7 +463,7 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 		}
 		logr.Info("google: sent delete instance request")
 
-		if *storageCleanupType == storage.Delete {
+		if *storageCleanupType == storage.Delete && instance.StorageIdentifier != "" {
 			logr.Info("google: waiting for instance deletion")
 			err = p.waitZoneOperation(ctx, instanceDeleteOperation.Name, zone)
 			if err != nil {

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -295,13 +295,29 @@ func (p *config) create(ctx context.Context, opts *types.InstanceCreateOpts, nam
 		}
 	}
 
-	requestID := uuid.New().String()
-	op, err := p.insertInstance(ctx, p.projectID, zone, requestID, in)
+	if opts.StorageOpts.Identifier != "" {
+		operations, err := p.attachPersistentDisk(ctx, opts, in, zone)
+		if err != nil {
+			logr.WithError(err).Errorln("google: failed to attach persistent disk")
+			return nil, err
+		}
+		for _, operation := range operations {
+			if operation != nil {
+				// Disk not present, wait for creation
+				err = p.waitZoneOperation(ctx, operation.Name, zone)
+				if err != nil {
+					logr.WithError(err).Errorln("google: persistent disk creation operation failed")
+					return nil, err
+				}
+			}
+		}
+	}
+
+	op, err := p.insertInstance(ctx, p.projectID, zone, uuid.New().String(), in)
 	if err != nil {
 		logr.WithError(err).Errorln("google: failed to provision VM")
 		return nil, err
 	}
-
 	err = p.waitZoneOperation(ctx, op.Name, zone)
 	if err != nil {
 		logr.WithError(err).Errorln("instance insert operation failed")
@@ -328,6 +344,46 @@ func (p *config) create(ctx context.Context, opts *types.InstanceCreateOpts, nam
 		Debugln("google: [provision] complete")
 
 	return &instanceMap, nil
+}
+
+func (p *config) attachPersistentDisk(
+	ctx context.Context,
+	opts *types.InstanceCreateOpts,
+	in *compute.Instance,
+	diskZone string,
+) ([]*compute.Operation, error) {
+	storageIdentifiers := strings.Split(opts.StorageOpts.Identifier, ",")
+	var operations []*compute.Operation
+	for i, diskName := range storageIdentifiers {
+		requestID := uuid.New().String()
+		diskType := fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, diskZone, "pd-balanced")
+		diskSize, err := strconv.ParseInt(opts.StorageOpts.Size, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Error converting string to int64: %v\n", err)
+		}
+		persistentDisk := &compute.Disk{
+			Name:   diskName,
+			SizeGb: diskSize,
+			Type:   diskType,
+			Zone:   diskZone,
+		}
+		op, err := p.createPersistentDiskIfNotExists(ctx, p.projectID, diskZone, requestID, persistentDisk)
+		if err != nil {
+			return nil, err
+		}
+		operations = append(operations, op)
+
+		// attach to instance
+		attachedDisk := &compute.AttachedDisk{
+			DeviceName: fmt.Sprintf("disk-%d", i),
+			Boot:       false,
+			Type:       "PERSISTENT",
+			Source:     "projects/" + p.projectID + "/zones/" + diskZone + "/disks/" + diskName,
+			Mode:       "READ_WRITE",
+		}
+		in.Disks = append(in.Disks, attachedDisk)
+	}
+	return operations, nil
 }
 
 // Set the instance metadata (not network tags)
@@ -376,7 +432,8 @@ func (p *config) Destroy(ctx context.Context, instances []*types.Instance) (err 
 	return p.DestroyInstanceAndStorage(ctx, instances, nil)
 }
 
-func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*types.Instance, _ *storage.CleanupType) (err error) {
+func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*types.Instance, storageCleanupType *storage.CleanupType) error {
+	var err error
 	if len(instances) == 0 {
 		return errors.New("no instances provided")
 	}
@@ -394,9 +451,7 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 			}
 		}
 
-		requestID := uuid.New().String()
-
-		_, err = p.deleteInstance(ctx, p.projectID, zone, instance.ID, requestID)
+		instanceDeleteOperation, err := p.deleteInstance(ctx, p.projectID, zone, instance.ID, uuid.New().String())
 		if err != nil {
 			// https://github.com/googleapis/google-api-go-client/blob/master/googleapi/googleapi.go#L135
 			if gerr, ok := err.(*googleapi.Error); ok &&
@@ -407,8 +462,41 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 			}
 		}
 		logr.Info("google: sent delete instance request")
+
+		if *storageCleanupType == storage.Delete {
+			logr.Info("google: waiting for instance deletion")
+			err = p.waitZoneOperation(ctx, instanceDeleteOperation.Name, zone)
+			if err != nil {
+				logr.WithError(err).Errorln("google: could not delete instance. skipping disk deletion")
+				return err
+			}
+			logr.Info("google: deleting persistent disk")
+			storageIdentifiers := strings.Split(instance.StorageIdentifier, ",")
+			for _, storageIdentifier := range storageIdentifiers {
+				diskDeleteOperation, err := p.deletePersistentDisk(
+					ctx,
+					p.projectID,
+					zone,
+					storageIdentifier,
+					uuid.New().String(),
+				)
+				if err != nil {
+					var googleErr *googleapi.Error
+					if errors.As(err, &googleErr) &&
+						googleErr.Code == http.StatusNotFound {
+						logr.WithError(err).Errorln("google: persistent disk %s not found", storageIdentifier)
+					}
+				}
+				err = p.waitZoneOperation(ctx, diskDeleteOperation.Name, zone)
+				if err != nil {
+					logr.WithError(err).Errorln("google: could not delete persistent disk %s", storageIdentifier)
+					return err
+				}
+			}
+		}
+
 	}
-	return
+	return err
 }
 
 func (p *config) Hibernate(ctx context.Context, instanceID, _ string) error {
@@ -504,13 +592,43 @@ func (p *config) resumeInstance(ctx context.Context, projectID, zone, name strin
 
 func (p *config) insertInstance(ctx context.Context, projectID, zone, requestID string, in *compute.Instance) (*compute.Operation, error) {
 	return retry(ctx, insertRetries, secSleep, func() (*compute.Operation, error) {
-		return p.service.Instances.Insert(projectID, zone, in).RequestId(requestID).Context(ctx).Do()
+		op, err := p.service.Instances.Insert(projectID, zone, in).RequestId(requestID).Context(ctx).Do()
+		if err != nil {
+			return op, err
+		}
+		return op, err
 	})
 }
 
 func (p *config) deleteInstance(ctx context.Context, projectID, zone, instanceID, requestID string) (*compute.Operation, error) {
 	return retry(ctx, deleteRetries, secSleep, func() (*compute.Operation, error) {
 		return p.service.Instances.Delete(projectID, zone, instanceID).RequestId(requestID).Context(ctx).Do()
+	})
+}
+
+func (p *config) createPersistentDiskIfNotExists(ctx context.Context, projectID, zone, requestID string, disk *compute.Disk) (*compute.Operation, error) {
+	// Check if the disk already exists
+	_, err := retry(ctx, getRetries, secSleep, func() (*compute.Disk, error) {
+		return p.service.Disks.Get(projectID, zone, disk.Name).Context(ctx).Do()
+	})
+
+	var getErr *googleapi.Error
+	if errors.As(err, &getErr) && getErr.Code == 404 {
+		// Disk doesn't exist, create it
+		return retry(ctx, insertRetries, secSleep, func() (*compute.Operation, error) {
+			return p.service.Disks.Insert(projectID, zone, disk).RequestId(requestID).Context(ctx).Do()
+		})
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to check disk existence: %w", err)
+	}
+
+	// Disk already exists
+	return nil, nil
+}
+
+func (p *config) deletePersistentDisk(ctx context.Context, projectID, zone, diskName, requestID string) (*compute.Operation, error) {
+	return retry(ctx, deleteRetries, secSleep, func() (*compute.Operation, error) {
+		return p.service.Disks.Delete(projectID, zone, diskName).RequestId(requestID).Context(ctx).Do()
 	})
 }
 
@@ -544,6 +662,7 @@ func (p *config) mapToInstance(vm *compute.Instance, zone string, opts *types.In
 		IsHibernated:               false,
 		Port:                       lehelper.LiteEnginePort,
 		EnableNestedVirtualization: enableNestedVitualization,
+		StorageIdentifier:          opts.StorageOpts.Identifier,
 	}
 }
 

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -466,16 +466,16 @@ func (m *Manager) cleanPool(ctx context.Context, pool *poolEntry, query *types.Q
 }
 
 func (m *Manager) CleanPools(ctx context.Context, destroyBusy, destroyFree bool) error {
-	var returnError error
-	for _, pool := range m.poolMap {
-		err := m.cleanPool(ctx, pool, nil, destroyBusy, destroyFree)
-		if err != nil {
-			returnError = err
-			logrus.Errorf("failed to clean pool %s with error: %s", pool.Name, err)
-		}
-	}
+	//var returnError error
+	//for _, pool := range m.poolMap {
+	//	err := m.cleanPool(ctx, pool, nil, destroyBusy, destroyFree)
+	//	if err != nil {
+	//		returnError = err
+	//		logrus.Errorf("failed to clean pool %s with error: %s", pool.Name, err)
+	//	}
+	//}
 
-	return returnError
+	return nil
 }
 
 func (m *Manager) PingDriver(ctx context.Context) error {
@@ -615,6 +615,7 @@ func (m *Manager) setupInstance(
 			CephPoolIdentifier: storageConfig.CephPoolIdentifier,
 			Identifier:         storageConfig.Identifier,
 			Size:               storageConfig.Size,
+			Type:               storageConfig.Type,
 		}
 	}
 	createOptions.AutoInjectionBinaryURI = m.autoInjectionBinaryURI

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -466,16 +466,16 @@ func (m *Manager) cleanPool(ctx context.Context, pool *poolEntry, query *types.Q
 }
 
 func (m *Manager) CleanPools(ctx context.Context, destroyBusy, destroyFree bool) error {
-	//var returnError error
-	//for _, pool := range m.poolMap {
-	//	err := m.cleanPool(ctx, pool, nil, destroyBusy, destroyFree)
-	//	if err != nil {
-	//		returnError = err
-	//		logrus.Errorf("failed to clean pool %s with error: %s", pool.Name, err)
-	//	}
-	//}
+	var returnError error
+	for _, pool := range m.poolMap {
+		err := m.cleanPool(ctx, pool, nil, destroyBusy, destroyFree)
+		if err != nil {
+			returnError = err
+			logrus.Errorf("failed to clean pool %s with error: %s", pool.Name, err)
+		}
+	}
 
-	return nil
+	return returnError
 }
 
 func (m *Manager) PingDriver(ctx context.Context) error {

--- a/command/harness/common.go
+++ b/command/harness/common.go
@@ -1,13 +1,14 @@
 package harness
 
 type InstanceInfo struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	IPAddress string `json:"ip_address"`
-	Port      int64  `json:"port"`
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	Provider  string `json:"provider"`
-	PoolName  string `json:"pool_name"`
-	Zone      string `json:"zone"`
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	IPAddress         string `json:"ip_address"`
+	Port              int64  `json:"port"`
+	OS                string `json:"os"`
+	Arch              string `json:"arch"`
+	Provider          string `json:"provider"`
+	PoolName          string `json:"pool_name"`
+	Zone              string `json:"zone"`
+	StorageIdentifier string `json:"storage_identifier"`
 }

--- a/command/harness/delegate/delegate.go
+++ b/command/harness/delegate/delegate.go
@@ -166,21 +166,21 @@ func (c *delegateCommand) handlePoolOwner(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	//stageID := r.URL.Query().Get("stageId")
-	//if stageID != "" {
-	//	entity, err := c.stageOwnerStore.Find(context.Background(), stageID)
-	//	if err != nil {
-	//		logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageID).Error("failed to find the stage in store")
-	//		httprender.OK(w, poolOwnerResponse{Owner: false})
-	//		return
-	//	}
-	//
-	//	if entity.PoolName != poolName {
-	//		logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageID).Errorf("found stage with different pool: %s", entity.PoolName)
-	//		httprender.OK(w, poolOwnerResponse{Owner: false})
-	//		return
-	//	}
-	//}
+	stageID := r.URL.Query().Get("stageId")
+	if stageID != "" {
+		entity, err := c.stageOwnerStore.Find(context.Background(), stageID)
+		if err != nil {
+			logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageID).Error("failed to find the stage in store")
+			httprender.OK(w, poolOwnerResponse{Owner: false})
+			return
+		}
+
+		if entity.PoolName != poolName {
+			logrus.WithError(err).WithField("pool", poolName).WithField("stageId", stageID).Errorf("found stage with different pool: %s", entity.PoolName)
+			httprender.OK(w, poolOwnerResponse{Owner: false})
+			return
+		}
+	}
 
 	httprender.OK(w, poolOwnerResponse{Owner: true})
 }

--- a/command/harness/helper.go
+++ b/command/harness/helper.go
@@ -75,8 +75,9 @@ func buildInstanceFromRequest(instanceInfo InstanceInfo) *types.Instance { //nol
 			OS:   instanceInfo.OS,
 			Arch: instanceInfo.Arch,
 		},
-		IsHibernated: false,
-		Port:         instanceInfo.Port,
-		Zone:         instanceInfo.Zone,
+		IsHibernated:      false,
+		Port:              instanceInfo.Port,
+		Zone:              instanceInfo.Zone,
+		StorageIdentifier: instanceInfo.StorageIdentifier,
 	}
 }

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -192,15 +192,16 @@ func HandleSetup(
 
 	metrics.BuildCount.WithLabelValues(selectedPool, instance.OS, instance.Arch, string(instance.Provider), strconv.FormatBool(poolManager.IsDistributed()), instance.Zone, owner).Inc()
 	instanceInfo := InstanceInfo{
-		ID:        instance.ID,
-		Name:      instance.Name,
-		IPAddress: instance.Address,
-		Port:      instance.Port,
-		OS:        platform.OS,
-		Arch:      platform.Arch,
-		Provider:  string(instance.Provider),
-		PoolName:  selectedPool,
-		Zone:      instance.Zone,
+		ID:                instance.ID,
+		Name:              instance.Name,
+		IPAddress:         instance.Address,
+		Port:              instance.Port,
+		OS:                platform.OS,
+		Arch:              platform.Arch,
+		Provider:          string(instance.Provider),
+		PoolName:          selectedPool,
+		Zone:              instance.Zone,
+		StorageIdentifier: instance.StorageIdentifier,
 	}
 	resp := &SetupVMResponse{InstanceID: instance.ID, IPAddress: instance.Address, GitspacesPortMappings: instance.GitspacePortMappings, InstanceInfo: instanceInfo}
 

--- a/types/types.go
+++ b/types/types.go
@@ -144,6 +144,7 @@ type StorageOpts struct {
 	CephPoolIdentifier string
 	Identifier         string
 	Size               string
+	Type               string
 }
 
 type GitspaceAgentConfig struct {
@@ -157,4 +158,5 @@ type StorageConfig struct {
 	CephPoolIdentifier string `json:"ceph_pool_identifier"`
 	Identifier         string `json:"identifier"`
 	Size               string `json:"size"`
+	Type               string `json:"type" default:"pd-balanced"`
 }


### PR DESCRIPTION
# Description
1. Create Disk
    - Create (if required) and attach the persistent disk to the VM.
    - Wait for the disk to be created and then initiate instance creation.
    - Pass storage type (example: "pd-balanced")
    - storage_identifier supports a comma-separated list of identifiers, to support 2 separate disks (1 for gitspace and 1 for docker) in the future.
2. Delete Disk
    - Delete the disk on Delete Gitspace (StorageCleanupType.DELETE).
    - Disk would retained in case of Stop Gitspace (StorageCleanupType.DETACH).
    - If the disk needs to be deleted, wait for instance deletion to complete and then hit the delete disk API.
    - Add storage_identifier in instance info (This will be sent in the destroy request to identify the disk and delete it)
    - Pass StorageCleanupType in VMCleanupRequest
3. Skip CDE VMs from cleanup by setting "retain": true label

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
