### PR TITLE
fix: [CI-16188]: update health timeout check for windows and other OS

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -330,7 +330,7 @@ func handleSetup(
 	// try the healthcheck api on the lite-engine until it responds ok
 	logr.Traceln("running healthcheck and waiting for an ok response")
 	performDNSLookup := drivers.ShouldPerformDNSLookup(ctx, instance.Platform.OS)
-	if instance.OS == "windows" {
+	if instance.Platform.OS == "windows" {
 		healthCheckTimeout = healthCheckWindowsTimeout
 	}
 	if _, err = client.RetryHealth(ctx, healthCheckTimeout, performDNSLookup); err != nil {

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -48,9 +48,10 @@ type SetupVMResponse struct {
 }
 
 var (
-	healthCheckTimeout = 5 * time.Minute
-	freeAccount        = "free"
-	noContext          = context.Background()
+	healthCheckTimeout        = 3 * time.Minute
+	healthCheckWindowsTimeout = 5 * time.Minute
+	freeAccount               = "free"
+	noContext                 = context.Background()
 )
 
 // HandleSetup tries to setup an instance in any of the pools given in the setup request.
@@ -329,7 +330,9 @@ func handleSetup(
 	// try the healthcheck api on the lite-engine until it responds ok
 	logr.Traceln("running healthcheck and waiting for an ok response")
 	performDNSLookup := drivers.ShouldPerformDNSLookup(ctx, instance.Platform.OS)
-
+	if instance.OS == "windows" {
+		healthCheckTimeout = healthCheckWindowsTimeout
+	}
 	if _, err = client.RetryHealth(ctx, healthCheckTimeout, performDNSLookup); err != nil {
 		go cleanUpInstanceFn(true)
 		return nil, fmt.Errorf("failed to call lite-engine retry health: %w", err)


### PR DESCRIPTION
# Commit Checklist

The default timeout for Init Step VM is 5 min,  In this PR this is updated.
For Windows it is kept 5 mins and for Linux and Mac os it is kept 3 min.

Below are testing details image:

## Linux AMD64
<img width="1726" alt="Screenshot 2025-02-07 at 3 49 40 PM" src="https://github.com/user-attachments/assets/bd383a79-e0de-4f64-b52d-f4739f137715" />

## Linux ARM64
<img width="1728" alt="Screenshot 2025-02-07 at 3 50 09 PM" src="https://github.com/user-attachments/assets/b9d77d8e-6709-4a92-91ff-a04b5119d036" />

## Mac
<img width="1720" alt="Screenshot 2025-02-07 at 3 50 23 PM" src="https://github.com/user-attachments/assets/0fd062de-bf9e-46c6-8d88-b926e04128ac" />

## Windows
<img width="1702" alt="Screenshot 2025-02-07 at 3 49 01 PM" src="https://github.com/user-attachments/assets/8e87e6f8-9e6e-4930-b03f-f613c6dee6d3" />



Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.


