### PR TITLE
feat: [CI-16207]: Add stderr logs for failed tasks

### DIFF
--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -310,6 +310,7 @@ chmod 777 /usr/bin/plugin
 
 const macArm64Script = `
 #!/usr/bin/env bash
+set -e
 mkdir /tmp/certs/
 
 echo {{ .CACert | base64 }} | base64 -d >> {{ .CaCertPath }}

--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -88,6 +88,7 @@ func Custom(templateText string, params *Params) (payload string, err error) {
 
 const linuxScript = `
 #!/usr/bin/bash
+set -e
 mkdir {{ .CertDir }}
 
 echo {{ .CACert | base64 }} | base64 -d >> {{ .CaCertPath }}

--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -729,10 +729,10 @@ func (p *config) getAllocationsForJob(logr *logrus.Entry, id string) {
 	// Marshal allocState to JSON
 	allocStateBytes, err := json.MarshalIndent(allocState, "", "  ")
 	if err == nil {
-		logr.WithField("allocState", string(allocStateBytes)).Infoln("scheduler: successfully fetched job allocations")
+		logr.WithField("alloc_state", string(allocStateBytes)).Infoln("scheduler: successfully fetched job allocations")
 	} else {
 		// fallback
-		logr.WithField("allocState", allocState).Infoln("scheduler: successfully fetched job allocations")
+		logr.WithField("alloc_state", allocState).Infoln("scheduler: successfully fetched job allocations")
 	}
 }
 
@@ -756,9 +756,9 @@ func (p *config) streamStdErrLogs(allocation *api.Allocation, taskName string, l
 			if logLine == nil {
 				return
 			}
-			logr.WithField("taskName", taskName).WithField("stderr_data", string(logLine.Data)).Errorln("scheduler: successfully failed task stderr logs")
+			logr.WithField("task_name", taskName).WithField("stderr_data", string(logLine.Data)).Errorln("scheduler: successfully failed task stderr logs")
 		case <-timeout:
-			logr.WithField("taskName", taskName).Warnln("scheduler: log streaming timed out")
+			logr.WithField("task_name", taskName).Warnln("scheduler: log streaming timed out")
 			close(cancel)
 		}
 	}

--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"text/template"
@@ -18,8 +19,9 @@ import (
 	cf "github.com/drone-runners/drone-runner-aws/command/config"
 	"github.com/drone-runners/drone-runner-aws/command/harness/storage"
 	"github.com/drone-runners/drone-runner-aws/types"
-	"github.com/drone/runner-go/logger"
+	"github.com/harness/lite-engine/logger"
 	"github.com/hashicorp/nomad/api"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 )
 
@@ -189,7 +191,11 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 		resourceJob, resourceJobID = p.resourceJob(cpus, memGB, p.virtualizer.GetMachineFrequency(), len(opts.GitspaceOpts.Ports), vm, class, p.virtualizer.GetHealthCheckupGenerator())
 	}
 
-	logr := logger.FromContext(ctx).WithField("vm", vm).WithField("node_class", class).WithField("resource_job_id", resourceJobID)
+	originalLogr := logger.FromContext(ctx).WithField("vm", vm).WithField("node_class", class).WithField("resource_job_id", resourceJobID)
+	// Create a new logger instance that doesn't share the original's internal state
+	logger := logrus.New()
+	logger.SetOutput(os.Stdout)
+	logr := logger.WithFields(originalLogr.Data)
 
 	logr.Infoln("scheduler: finding a node which has available resources ... ")
 
@@ -396,7 +402,7 @@ func (p *config) resourceJob(cpus, memGB, machineFrequencyMhz, gitspacesPortCoun
 }
 
 // fetchMachine returns details of the machine where the job has been allocated
-func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, err error) {
+func (p *config) fetchMachine(logr *logrus.Entry, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, err error) {
 	// Get the allocation corresponding to this job submission. If this call fails, there is not much we can do in terms
 	// of cleanup - as the job has created a virtual machine but we could not parse the node identifier.
 	l, _, err := p.client.Jobs().Allocations(id, false, nil)
@@ -618,7 +624,7 @@ func (p *config) Start(ctx context.Context, instanceID, poolName string) (string
 // if remove is set to true, it deregisters the job in case the job hasn't reached a terminal state
 // before the timeout or before the context is marked as Done.
 // An error is returned if the job did not reach a terminal state
-func (p *config) pollForJob(ctx context.Context, id string, logr logger.Logger, timeout time.Duration, remove bool, terminalStates []JobStatus) (*api.Job, error) {
+func (p *config) pollForJob(ctx context.Context, id string, logr *logrus.Entry, timeout time.Duration, remove bool, terminalStates []JobStatus) (*api.Job, error) {
 	terminalStates = append(terminalStates, Dead) // we always return from poll if the job is dead
 	maxPollTime := time.After(timeout)
 	terminal := false
@@ -675,7 +681,7 @@ L:
 
 // deregisterJob stops the job in Nomad
 // if purge is set to true, it gc's it from nomad state as well
-func (p *config) deregisterJob(logr logger.Logger, id string, purge bool) error { //nolint:unparam
+func (p *config) deregisterJob(logr *logrus.Entry, id string, purge bool) error { //nolint:unparam
 	logr.WithField("job_id", id).WithField("purge", purge).Traceln("scheduler: trying to deregister job")
 	_, _, err := p.client.Jobs().Deregister(id, purge, &api.WriteOptions{})
 	if err != nil {
@@ -686,7 +692,7 @@ func (p *config) deregisterJob(logr logger.Logger, id string, purge bool) error 
 	return nil
 }
 
-func (p *config) getAllocationsForJob(logr logger.Logger, id string) {
+func (p *config) getAllocationsForJob(logr *logrus.Entry, id string) {
 	allocs, _, err := p.client.Jobs().Allocations(id, true, &api.QueryOptions{})
 	if err != nil || allocs == nil || len(allocs) == 0 || allocs[0] == nil {
 		logr.WithError(err).Errorln("scheduler: unable to get allocations")
@@ -704,6 +710,11 @@ func (p *config) getAllocationsForJob(logr logger.Logger, id string) {
 				}
 			}
 			allocState[taskName] = events
+
+			// Check if the task has failed
+			if taskState.Failed {
+				p.streamStdErrLogs(alloc.ID, taskName, logr)
+			}
 		}
 	}
 	// Marshal allocState to JSON
@@ -713,6 +724,35 @@ func (p *config) getAllocationsForJob(logr logger.Logger, id string) {
 	} else {
 		// fallback
 		logr.WithField("allocState", allocState).Infoln("scheduler: successfully fetched job allocations")
+	}
+}
+
+func (p *config) streamStdErrLogs(allocID, taskName string, logr *logrus.Entry) {
+	allocation, _, err := p.client.Allocations().Info(allocID, &api.QueryOptions{})
+	if allocation == nil || err != nil {
+		return
+	}
+	cancel := make(chan struct{})
+	logs, _ := p.client.AllocFS().Logs(allocation, false, taskName, "stderr", "", int64(0), cancel, &api.QueryOptions{})
+	if logs == nil {
+		return
+	}
+	timeout := time.After(10 * time.Second) // Set the timeout duration
+	// Handle logs in real-time with a timeout
+	for {
+		select {
+		case <-cancel:
+			return
+		case logLine := <-logs:
+			// Print each log line received
+			if logLine == nil {
+				return
+			}
+			logr.WithField("taskName", taskName).WithField("stderr_data", string(logLine.Data)).Errorln("scheduler: successfully failed task stderr logs")
+		case <-timeout:
+			logr.WithField("taskName", taskName).Warnln("scheduler: log streaming timed out")
+			close(cancel)
+		}
 	}
 }
 


### PR DESCRIPTION
Add stderr logs for failure tasks in a job.

```
time="2025-02-07T18:05:57+05:30" level=error msg="scheduler: successfully failed task stderr logs" init_job_id=init_job_oyjhkd2yhap4xcgru0tm node_class=CI_QA node_ip=15.204.85.27 node_port=26739 resource_job_id=init_job_resources_oyjhkd2yhap4xcgru0tm stage_runtime_id=s4JFBtrkR5eFBYVT3OE_YA stderr_data="--2025-02-07 12:35:35--  https://github.com/harness/lite-engineee/releases/download/v0.5.94//lite-engine-linux-amd64\nResolving github.com (github.com)... 140.82.116.3\nConnecting to github.com (github.com)|140.82.116.3|:443... connected.\nHTTP request sent, awaiting response... 404 Not Found\nGiving up.\n\nSetting --output-document (outputdocument) to /usr/bin/lite-engine\nDEBUG output created by Wget 1.21.2 on linux-gnu.\n\nReading HSTS entries from /home/harness/.wget-hsts\nURI encoding = ‘UTF-8’\nCaching github.com => 140.82.116.4\nCreated socket 4.\nReleasing 0x0000561419ad7df0 (new refcount 1).\nInitiating SSL handshake.\nHandshake successful; connected socket 4 to SSL handle 0x0000561419ad9670\ncertificate:\n  subject: CN=github.com\n  issuer:  CN=Sectigo ECC Domain Validation Secure Server CA,O=Sectigo Limited,L=Salford,ST=Greater Manchester,C=GB\nX509 certificate successfully verified and matches host github.com\n\n---request begin---\nGET /harness/lite-engineee/releases/download/v0.5.94//lite-engine-linux-amd64 HTTP/1.1\r\nHost: github.com\r\nUser-Agent: Wget/1.21.2\r\nAccept: */*\r\nAccept-Encoding: identity\r\nConnection: Keep-Alive\r\n\r\n---request end---\n\n---response begin---\nHTTP/1.1 404 Not Found\r\nServer: GitHub.com\r\nDate: Fri, 07 Feb 2025 12:34:29 GMT\r\nContent-Type: text/plain; charset=utf-8\r\nVary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With\r\nCache-Control: no-cache\r\nStrict-Transport-Security: max-age=31536000; includeSubdomains; preload\r\nX-Frame-Options: deny\r\nX-Content-Type-Options: nosniff\r\nX-XSS-Protection: 0\r\nReferrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin\r\nContent-Security-Policy: default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'\r\nContent-Length: 9\r\nX-GitHub-Request-Id: 9540:11D3F7:D705FB7:DD32E9F:67A5FE17\r\n\r\n---response end---\nRegistered socket 4 for persistent reuse.\nParsed Strict-Transport-Security max-age = 31536000, includeSubDomains = true\nUpdated HSTS host: github.com:443 (max-age: 31536000, includeSubdomains: true)\nURI content encoding = ‘utf-8’\nSkipping 9 bytes of body: [Not Found] done.\nhttps://github.com/harness/lite-engineee/releases/download/v0.5.94//lite-engine-linux-amd64:\n2025-02-07 12:35:35 ERROR 404: Not Found.\n" taskName=ignite_exec vm=oyjhkd2yhap4xcgru0tm
```

<img width="1345" alt="Screenshot 2025-02-07 at 6 10 42 PM" src="https://github.com/user-attachments/assets/ea71183d-7202-41f1-aa78-ba97507a894e" />

