### PR TITLE
feat: [PIPE-24820]: Remove syscall.Umask for windows builds

### DIFF
--- a/app/drivers/vmfusion/syscall_unix.go
+++ b/app/drivers/vmfusion/syscall_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package vmfusion
+
+import "syscall"
+
+func syscallUmask() {
+	_ = syscall.Umask(022) //nolint
+}

--- a/app/drivers/vmfusion/syscall_windows.go
+++ b/app/drivers/vmfusion/syscall_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+// +build windows
+
+package vmfusion
+
+func syscallUmask() {
+	// syscall umask is not supported on Windows
+}

--- a/app/drivers/vmfusion/utils.go
+++ b/app/drivers/vmfusion/utils.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/drone-runners/drone-runner-aws/app/drivers"
@@ -19,7 +18,7 @@ import (
 )
 
 func vmrun(args ...string) (string, string, error) { //nolint
-	_ = syscall.Umask(022) //nolint
+	syscallUmask()
 	cmd := exec.Command(vmrunbin, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
The runner would not build on windows before since Umask is not supported on windows. This lets the runner build on windows.

env GOOS="windows" GOARCH="amd64" CGO_ENABLED="1" CC="x86_64-w64-mingw32-gcc" go build generates windows builds

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
