### PR TITLE
feat: [CI-16060]: Update lite-engine version to v0.5.95

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -349,7 +349,7 @@ type EnvConfig struct {
 		AutoInjectionBinaryURI string `envconfig:"DRONE_HARNESS_AUTO_INJECTION_BINARY_URI"`
 	}
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.94/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.95/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.94
+	github.com/harness/lite-engine v0.5.95
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1
@@ -65,7 +65,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/harness/godotenv/v3 v3.0.1 // indirect
-	github.com/harness/ti-client v0.0.0-20250104064648-cba197bedd61 // indirect
+	github.com/harness/ti-client v0.0.0-20250211085345-7c82b29d1b3c // indirect
 	github.com/hashicorp/cronexpr v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,10 +236,10 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.94 h1:3eEEuairD172XlXCH9UV7G0GSyiAMk0PSSBQmdWmh5k=
-github.com/harness/lite-engine v0.5.94/go.mod h1:1jk1kygLSoZZDXIdR7M5O145eN4uFatoqU3tJups59o=
-github.com/harness/ti-client v0.0.0-20250104064648-cba197bedd61 h1:y8CWfjrKjLjbKPRqlmCYT3dj4S2lC5T17/l5qA7T1vc=
-github.com/harness/ti-client v0.0.0-20250104064648-cba197bedd61/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
+github.com/harness/lite-engine v0.5.95 h1:lvw+4OCtwEPLV+Kt9EllkqE/Q0NdJjfcS8IJTPkpXP4=
+github.com/harness/lite-engine v0.5.95/go.mod h1:/6AqaF3+ibpBG/vcPIzO4qQI8QaGFX1951qh1KxYZCk=
+github.com/harness/ti-client v0.0.0-20250211085345-7c82b29d1b3c h1:fAVNZiSrO9i8lQUo1joeEiOxHyqYwRxtVQivjrMeHpE=
+github.com/harness/ti-client v0.0.0-20250211085345-7c82b29d1b3c/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=


### PR DESCRIPTION
lite-engine buil tag: https://github.com/harness/lite-engine/commits/v0.5.95