### PR TITLE
[feat]: [CI-16881]: Currently encypted disks is only supported for io1 disk type. Adding this support for all aws disk types

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -297,6 +297,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 
 	for _, blockDeviceMapping := range in.BlockDeviceMappings {
 		if p.kmsKeyID != "" {
+			logr.Infoln("Creating encrypted volume")
 			blockDeviceMapping.Ebs.Encrypted = aws.Bool(true)
 			blockDeviceMapping.Ebs.KmsKeyId = aws.String(p.kmsKeyID)
 		}

--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -295,6 +295,13 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		}
 	}
 
+	for _, blockDeviceMapping := range in.BlockDeviceMappings {
+		if p.kmsKeyID != "" {
+			blockDeviceMapping.Ebs.Encrypted = aws.Bool(true)
+			blockDeviceMapping.Ebs.KmsKeyId = aws.String(p.kmsKeyID)
+		}
+	}
+
 	if p.CanHibernate() {
 		for _, blockDeviceMapping := range in.BlockDeviceMappings {
 			blockDeviceMapping.Ebs.Encrypted = aws.Bool(true)

--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -288,16 +288,11 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 	if p.volumeType == "io1" {
 		for _, blockDeviceMapping := range in.BlockDeviceMappings {
 			blockDeviceMapping.Ebs.Iops = aws.Int64(p.volumeIops)
-			if p.kmsKeyID != "" {
-				blockDeviceMapping.Ebs.Encrypted = aws.Bool(true)
-				blockDeviceMapping.Ebs.KmsKeyId = aws.String(p.kmsKeyID)
-			}
 		}
 	}
 
-	for _, blockDeviceMapping := range in.BlockDeviceMappings {
-		if p.kmsKeyID != "" {
-			logr.Infoln("Creating encrypted volume")
+	if p.kmsKeyID != "" {
+		for _, blockDeviceMapping := range in.BlockDeviceMappings {
 			blockDeviceMapping.Ebs.Encrypted = aws.Bool(true)
 			blockDeviceMapping.Ebs.KmsKeyId = aws.String(p.kmsKeyID)
 		}


### PR DESCRIPTION
This has been tested by using the gp3 image and making sure an encrypted disk is created