### PR TITLE
fix: [CI-16953]: Force DNS queries using google

### DIFF
--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -546,7 +546,7 @@ write_files:
 runcmd:
 - 'set -x'
 {{ if .ShouldUseGoogleDNS }}
-- 'echo "DNS=8.8.8.8 8.8.4.4\nFallbackDNS=1.1.1.1 1.0.0.1" | sudo tee -a /etc/systemd/resolved.conf'
+- 'echo "DNS=8.8.8.8 8.8.4.4\nFallbackDNS=1.1.1.1 1.0.0.1\nDomains=~." | sudo tee -a /etc/systemd/resolved.conf'
 - 'systemctl restart systemd-resolved'
 {{ end }}
 - 'ufw allow 9079'


### PR DESCRIPTION
<img width="1591" alt="Screenshot 2025-04-07 at 4 10 34 PM" src="https://github.com/user-attachments/assets/279587e0-82aa-4343-a8c9-d7169a4a3981" />
Tested with long running pipelines, the DNS resolution is working fine.