### PR TITLE
feat: [CI-16869]: HA for vm runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,96 @@ For more information about installing this runner look at the [installation docu
 
 For more information about configuring this runner look at the [configuration documentation](https://docs.drone.io/runner/vm/configuration/).
 
+## High Availablity
+We can deploy multiple replicas of runner to ensure high availablity. Below is an example of a deployment yaml that deploys 2 replicas of the runner behind a load balancer.
+<pre>---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: harness-delegate-ng
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drone-runner
+  namespace: harness-delegate-ng
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: drone-runner
+  template:
+    metadata:
+      labels:
+        app: drone-runner
+    spec:
+      containers:
+        - name: drone-runner
+          image: drone/drone-runner-aws:1.0.0-rc.to-be-added
+          args: ["delegate", "--pool", "/runner/gcp-pool.yml"]
+          env:
+            - name: DRONE_RUNNER_HA
+              value: "true"
+            - name: DRONE_DATABASE_DRIVER
+              value: postgres
+            - name: DRONE_DATABASE_DATASOURCE
+              value: host=runnerha-postgres-service.harness-delegate-ng.svc.cluster.local port=5431 user=admin password=password dbname=dlite sslmode=disable
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: config-volume
+              mountPath: /runner
+              readOnly: true
+      volumes:
+        - name: config-volume
+          projected:
+            sources:
+              - configMap:
+                  name: drone-runner-config
+              - secret:
+                  name: drone-runner-secret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: drone-runner-lb
+  namespace: harness-delegate-ng
+spec:
+  type: LoadBalancer
+  selector:
+    app: drone-runner
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP</pre>
+
+The load balancer ip obtained above can be used in delegate with env variable RUNNER_URL. 
+Populate DRONE_DATABASE_DATASOURCE accordingly. Note that above yaml mounts a volume config-volume with path /runner. Make sure your gcp-pool.yml and secrets required are mapped properly.
+Here is the gcp-pool.yaml used in above example
+
+<pre>version: "1"
+instances:
+  - name: linux-amd64
+    type: google
+    pool: 2
+    limit: 10
+    platform:
+      os: linux
+      arch: amd64 
+    spec:
+      hibernate: false
+      privateIP: true
+      account:
+        project_id: projectname
+        json_path: runner/gcp-secret.json
+      image: projects/projectname/global/images/hosted-vm-64
+      machine_type: e2-medium
+      zones:
+        - us-central1-a
+      disk:
+        size: 100</pre>
+
+
 ## Creating a build pipelines
 
 For more information about creating a build pipeline look at the [pipeline documentation](https://docs.drone.io/pipeline/aws/overview/).

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -472,7 +472,8 @@ func (m *Manager) Destroy(ctx context.Context, poolName, instanceID string, inst
 }
 
 func (m *Manager) BuildPools(ctx context.Context) error {
-	return m.forEach(ctx, m.GetTLSServerName(), nil, m.buildPoolWithMutex)
+	query := types.QueryParams{RunnerName: m.runnerName}
+	return m.forEach(ctx, m.GetTLSServerName(), &query, m.buildPoolWithMutex)
 }
 
 func (m *Manager) cleanPool(ctx context.Context, pool *poolEntry, query *types.QueryParams, destroyBusy, destroyFree bool) error {
@@ -514,7 +515,7 @@ func (m *Manager) cleanPool(ctx context.Context, pool *poolEntry, query *types.Q
 
 func (m *Manager) CleanPools(ctx context.Context, destroyBusy, destroyFree bool) error {
 	var returnError error
-	query := types.QueryParams{MatchLabels: map[string]string{"retain": "false"}}
+	query := types.QueryParams{RunnerName: m.runnerName, MatchLabels: map[string]string{"retain": "false"}}
 	for _, pool := range m.poolMap {
 		err := m.cleanPool(ctx, pool, &query, destroyBusy, destroyFree)
 		if err != nil {
@@ -971,6 +972,9 @@ func (m *Manager) checkInstanceConnectivity(ctx context.Context, tlsServerName, 
 }
 
 func (m *Manager) GetTLSServerName() string {
+	if m.runnerConfig.HA {
+		return "drone-runner-ha"
+	}
 	return m.runnerName
 }
 

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -330,6 +330,7 @@ type EnvConfig struct {
 	RunnerConfig struct {
 		HealthCheckTimeout        int64 `envconfig:"HEALTH_CHECK_TIMEOUT" default:"3"`
 		HealthCheckWindowsTimeout int64 `envconfig:"HEALTH_CHECK_WINDOWS_TIMEOUT" default:"5"`
+		HA                        bool  `envconfig:"DRONE_RUNNER_HA" default:"false"`
 	}
 
 	Dlite struct {

--- a/command/harness/delegate/delegate.go
+++ b/command/harness/delegate/delegate.go
@@ -114,7 +114,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 	c.poolManager = drivers.New(ctx, instanceStore, &c.env)
 
 	_, err = harness.SetupPoolWithEnv(ctx, &c.env, c.poolManager, c.poolFile)
-	defer harness.Cleanup(c.env.Settings.ReusePool, c.poolManager, true, true) //nolint: errcheck
+	defer harness.Cleanup(c.env.Settings.ReusePool, c.poolManager, false, true) //nolint: errcheck
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 
 	g.Go(func() error {
 		<-ctx.Done()
-		return harness.Cleanup(c.env.Settings.ReusePool, c.poolManager, true, true)
+		return harness.Cleanup(c.env.Settings.ReusePool, c.poolManager, false, true)
 	})
 
 	g.Go(func() error {

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -251,11 +251,8 @@ func handleSetup(
 	stageRuntimeID := r.ID
 
 	// try to provision an instance from the pool manager.
-	var query *types.QueryParams
-	if poolManager.IsDistributed() {
-		query = &types.QueryParams{
-			RunnerName: runnerName,
-		}
+	query := &types.QueryParams{
+		RunnerName: runnerName,
 	}
 
 	shouldUseGoogleDNS := false

--- a/types/types.go
+++ b/types/types.go
@@ -81,6 +81,7 @@ type Passwords struct {
 type RunnerConfig struct {
 	HealthCheckTimeout        int64
 	HealthCheckWindowsTimeout int64
+	HA                        bool
 }
 
 type Tmate struct {


### PR DESCRIPTION
This pr attempts to support running multiple replicas of vm runner in a kubernetes cluster while delegate being a single one. We are introducing this flag DRONE_RUNNER_HA which should be enabled in case we are deploying multiple replicas.
Load tested with one delegate and 8 runner replicas on kubernetes https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/RaghavTest/pipelines/raghavnginxbuild/executions/CB1dIPBSSv2O-Dkegv0EhA/pipeline?stage=5te4Ng8xRzCb3fqeyN7dMg&stageExecId=W3feAM0ZTCCuUzFHtijzXA
https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/RaghavTest/pipelines/raghavnginxbuild/executions/PcC7PawGRJyvbMttJ54MxA/pipeline
