### PR TITLE
feat: [CI-17257]: capture vm setup time in init logs

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -184,7 +184,7 @@ func HandleSetup(
 		}
 		metrics.WaitDurationCount.WithLabelValues(r.PoolID, instance.OS, instance.Arch,
 			driver, metric.ConvertBool(fallback), strconv.FormatBool(poolManager.IsDistributed()), owner).Observe(setupTime.Seconds())
-		logrus.Infof("init time for vm setup is %.2f", setupTime.Seconds())
+		logrus.Infof("init time for vm setup is %.2fs", setupTime.Seconds())
 	} else {
 		metrics.FailedCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), owner).Inc()
 		metrics.BuildCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), "", owner, "").Inc()

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -184,7 +184,7 @@ func HandleSetup(
 		}
 		metrics.WaitDurationCount.WithLabelValues(r.PoolID, instance.OS, instance.Arch,
 			driver, metric.ConvertBool(fallback), strconv.FormatBool(poolManager.IsDistributed()), owner).Observe(setupTime.Seconds())
-		logr.WithField("setupTime", setupTime).Traceln("init time for vm setup")
+		logrus.Infof("init time for vm setup is %.2f", setupTime.Seconds())
 	} else {
 		metrics.FailedCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), owner).Inc()
 		metrics.BuildCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), "", owner, "").Inc()

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -184,6 +184,7 @@ func HandleSetup(
 		}
 		metrics.WaitDurationCount.WithLabelValues(r.PoolID, instance.OS, instance.Arch,
 			driver, metric.ConvertBool(fallback), strconv.FormatBool(poolManager.IsDistributed()), owner).Observe(setupTime.Seconds())
+		logr.WithField("setupTime", setupTime).Traceln("init time for vm setup")
 	} else {
 		metrics.FailedCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), owner).Inc()
 		metrics.BuildCount.WithLabelValues(r.PoolID, platform.OS, platform.Arch, driver, strconv.FormatBool(poolManager.IsDistributed()), "", owner, "").Inc()


### PR DESCRIPTION
Log the VM setup time in the init logs

<img width="1724" alt="Screenshot 2025-04-28 at 10 02 56 AM" src="https://github.com/user-attachments/assets/d1215eef-06db-4298-b19c-a50641dd03d9" />
<img width="1727" alt="Screenshot 2025-04-28 at 11 22 50 AM" src="https://github.com/user-attachments/assets/532e9611-0169-4556-86e1-3d6abc291131" />



# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
