### PR TITLE
feat: [CI-17310]: destroy if hibernate connectivity fails

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -370,6 +370,7 @@ func handleSetup(
 	if instance.Platform.OS == "windows" {
 		healthCheckTimeout = healthCheckWindowsTimeout
 	}
+
 	if _, err = client.RetryHealth(ctx, healthCheckTimeout, performDNSLookup); err != nil {
 		go cleanUpInstanceFn(true)
 		return nil, fmt.Errorf("failed to call lite-engine retry health: %w", err)


### PR DESCRIPTION
#Description 
We saw that we are hibernating vms even if the lite engine connectivity check fails. Due to which, we will see init failures when we provision the. This pr deletes the vms which failed connectivity check before hibernation.


# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
