### PR TITLE
[feat]: [CI-17465]: reducing retry count to fail fast from github

### DIFF
--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -115,7 +115,7 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=10 --waitretry=10 -nv --debug ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=3 --waitretry=3 -nv --debug ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
@@ -128,7 +128,7 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
@@ -212,7 +212,7 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=10 --waitretry=10 -nv --debug ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=3 --waitretry=3 -nv --debug ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
@@ -225,7 +225,7 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
@@ -661,14 +661,14 @@ write_files:
 runcmd:
 - 'sudo service docker start'
 - 'sudo usermod -a -G docker ec2-user'
-- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + `'
+- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + `'
 - 'chmod 777 /usr/bin/lite-engine'
 {{ if .HarnessTestBinaryURI }}
 - 'wget -nv "{{ .HarnessTestBinaryURI }}/{{ .Platform.Arch }}/{{ .Platform.OS }}/bin/split_tests-{{ .Platform.OS }}_{{ .Platform.Arch }}" -O /usr/bin/split_tests'
 - 'chmod 777 /usr/bin/split_tests'
 {{ end }}
 {{ if .PluginBinaryURI }}
-- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `'
+- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `'
 - 'chmod 777 /usr/bin/plugin'
 {{ end }}
 {{ if .AutoInjectionBinaryURI }}

--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -115,7 +115,7 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=3 --waitretry=3 -nv --debug ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
@@ -128,7 +128,7 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
@@ -212,7 +212,7 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=3 --waitretry=3 -nv --debug ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
@@ -225,7 +225,7 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
@@ -661,14 +661,14 @@ write_files:
 runcmd:
 - 'sudo service docker start'
 - 'sudo usermod -a -G docker ec2-user'
-- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + `'
+- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + liteEngineUsrBinPath + `'
 - 'chmod 777 /usr/bin/lite-engine'
 {{ if .HarnessTestBinaryURI }}
 - 'wget -nv "{{ .HarnessTestBinaryURI }}/{{ .Platform.Arch }}/{{ .Platform.OS }}/bin/split_tests-{{ .Platform.OS }}_{{ .Platform.Arch }}" -O /usr/bin/split_tests'
 - 'chmod 777 /usr/bin/split_tests'
 {{ end }}
 {{ if .PluginBinaryURI }}
-- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `'
+- 'wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=10 --waitretry=10 ` + pluginUsrBinPath + `'
 - 'chmod 777 /usr/bin/plugin'
 {{ end }}
 {{ if .AutoInjectionBinaryURI }}

--- a/app/cloudinit/cloudinit.go
+++ b/app/cloudinit/cloudinit.go
@@ -115,11 +115,11 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=2 --waitretry=2 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=2 --waitretry=2 -nv --debug ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
-    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinFallbackPath + `
+    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=5 --waitretry=5 ` + liteEngineUsrBinFallbackPath + ` || /usr/bin/wget --retry-connrefused --tries=5 --waitretry=5 -nv --debug ` + liteEngineUsrBinFallbackPath + `
     echo "Successfully downloaded lite engine binary from fallback URL."
 fi
 chmod 777 /usr/bin/lite-engine
@@ -128,11 +128,11 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=2 --waitretry=2 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=2 --waitretry=2 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
-    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinFallbackPath + `
+    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=5 --waitretry=5 ` + pluginUsrBinFallbackPath + ` || wget --retry-connrefused --tries=5 --waitretry=5 ` + pluginUsrBinFallbackPath + `
     echo "Successfully downloaded plugin binary from fallback URL."
 fi
 chmod 777 /usr/bin/plugin
@@ -212,11 +212,11 @@ swapon /swapfile
 echo "done setting up swap space"
 
 echo "downloading lite engine binary"
-if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + liteEngineUsrBinPath + `; then
+if /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=2 --waitretry=2 ` + liteEngineUsrBinPath + ` || /usr/bin/wget --retry-connrefused --tries=2 --waitretry=2 -nv --debug ` + liteEngineUsrBinPath + `; then
     echo "Successfully downloaded lite engine binary from primary URL."
 else
     echo "Primary URL failed for lite-engine. Trying fallback URL..."
-    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + liteEngineUsrBinFallbackPath + `
+    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=5 --waitretry=5 ` + liteEngineUsrBinFallbackPath + ` || /usr/bin/wget --retry-connrefused --tries=5 --waitretry=5 -nv --debug ` + liteEngineUsrBinFallbackPath + `
     echo "Successfully downloaded lite engine binary from fallback URL."
 fi
 chmod 777 /usr/bin/lite-engine
@@ -225,11 +225,11 @@ cp "/etc/environment" $HOME/.env
 echo "SKIP_PREPARE_SERVER=true" >> $HOME/.env;
 
 {{ if .PluginBinaryURI }}
-if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=3 --waitretry=3 ` + pluginUsrBinPath + `; then
+if wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=2 --waitretry=2 ` + pluginUsrBinPath + ` || wget --retry-connrefused --tries=2 --waitretry=2 ` + pluginUsrBinPath + `; then
     echo "Successfully downloaded plugin binary from primary URL."
 else
     echo "Primary URL failed for plugin. Trying fallback URL..."
-    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=10 --waitretry=10 ` + pluginUsrBinFallbackPath + `
+    /usr/bin/wget --retry-connrefused --retry-on-host-error --retry-on-http-error=503,404,429 --tries=5 --waitretry=5 ` + pluginUsrBinFallbackPath + ` || wget --retry-connrefused --tries=5 --waitretry=5 ` + pluginUsrBinFallbackPath + `
     echo "Successfully downloaded plugin binary from fallback URL."
 fi
 chmod 777 /usr/bin/plugin


### PR DESCRIPTION

1. changes are done only in linux Script & gitspacesLinuxScript (Baremetal) for plugin and le binaries 
2. All the other places primary source download fails in 3 retries already 

Testing : 

tested by giving primary url wrong link and verified 3 times download retry 

<img width="1693" alt="Screenshot 2025-05-14 at 21 29 10" src="https://github.com/user-attachments/assets/298fbfa9-cc32-43ae-b4ef-d22979e8077d" />
<img width="1693" alt="Screenshot 2025-05-14 at 21 29 20" src="https://github.com/user-attachments/assets/10b7f805-0c9b-4efa-a301-d3736fc262a1" />

tested primary source download post script changes 


<img width="1700" alt="Screenshot 2025-05-14 at 21 55 15" src="https://github.com/user-attachments/assets/6fec08c4-085d-41f2-a6f6-4a6d03d1a81c" />





# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
