### PR TITLE
fix: [CI-16878]: update LE for maven build cache

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -358,8 +358,8 @@ type EnvConfig struct {
 		AutoInjectionBinaryURI  string `envconfig:"DRONE_HARNESS_AUTO_INJECTION_BINARY_URI"`
 	}
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.106/"`
-		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.106/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.109/"`
+		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.109/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -355,7 +355,7 @@ type EnvConfig struct {
 		PluginBinaryURI         string `envconfig:"DRONE_PLUGIN_BINARY_URI" default:"https://github.com/drone/plugin/releases/download/v3.9.3-beta"`
 		PluginBinaryFallbackURI string `envconfig:"DRONE_PLUGIN_BINARY_FALLBACK_URI" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-plugin/v3.9.3-beta"`
 		PurgerTime              int64  `envconfig:"DRONE_PURGER_TIME_MINUTES" default:"30"`
-		AutoInjectionBinaryURI  string `envconfig:"DRONE_HARNESS_AUTO_INJECTION_BINARY_URI"`
+		AutoInjectionBinaryURI  string `envconfig:"DRONE_HARNESS_AUTO_INJECTION_BINARY_URI" default:"https://app.harness.io/storage/harness-download/harness-ti/auto-injection/1.0.7"`
 	}
 	LiteEngine struct {
 		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.109/"`

--- a/command/harness/delegate/delegate.go
+++ b/command/harness/delegate/delegate.go
@@ -91,7 +91,7 @@ func (c *delegateCommand) run(*kingpin.ParseContext) error {
 		env.Settings.HarnessTestBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/split_tests"
 	}
 	if env.Settings.AutoInjectionBinaryURI == "" {
-		env.Settings.AutoInjectionBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/auto-injection/1.0.3"
+		env.Settings.AutoInjectionBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/auto-injection/1.0.7"
 	}
 	c.env = env
 	// setup the global logrus logger.

--- a/command/harness/dlite/dlite.go
+++ b/command/harness/dlite/dlite.go
@@ -97,7 +97,7 @@ func (c *dliteCommand) run(*kingpin.ParseContext) error {
 		env.Settings.HarnessTestBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/split_tests"
 	}
 	if env.Settings.AutoInjectionBinaryURI == "" {
-		env.Settings.AutoInjectionBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/auto-injection/1.0.6"
+		env.Settings.AutoInjectionBinaryURI = "https://app.harness.io/storage/harness-download/harness-ti/auto-injection/1.0.7"
 	}
 	c.env = env
 	// setup the global logrus logger.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.106
+	github.com/harness/lite-engine v0.5.109
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.106 h1:qSJPQm1152rISQwn6g/74PH8UYYZ9yBch3sii/sJuaw=
-github.com/harness/lite-engine v0.5.106/go.mod h1:tVezSnV3ATn0GHXFy6aa3A2v7JKPcqIUd4EeMe5zdgk=
+github.com/harness/lite-engine v0.5.109 h1:iwcL4VUVghbGXiQ9QQR9ePtPStWtIgya858jlNmolY0=
+github.com/harness/lite-engine v0.5.109/go.mod h1:tVezSnV3ATn0GHXFy6aa3A2v7JKPcqIUd4EeMe5zdgk=
 github.com/harness/ti-client v0.0.0-20250415222455-1feda5858e23 h1:cIvDa75fXeNQu4l9levHvtjplxV8tcUvkOmxvUwrsS0=
 github.com/harness/ti-client v0.0.0-20250415222455-1feda5858e23/go.mod h1:/ow4f34mPgr5KPkzKxmBUB4cC09OjzStcLX6R8+43TI=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=


### PR DESCRIPTION
Description- 
This change include the new LE v0.5.109
and auto-injection v1.0.7 for maven build cache.

Testing done- tested maven/gradle build cache with the LE/runner version - working as expected with autoinjection.
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/bb15db18-ce81-4be1-9c61-f7ee51d88566" />


# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
