### PR TITLE
feat: [CI-17204]: volumes tags aws

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -51,6 +51,7 @@ type config struct {
 	allocPublicIP bool
 	volumeType    string
 	volumeSize    int64
+	volumeTags    map[string]string
 	volumeIops    int64
 	kmsKeyID      string
 	deviceName    string
@@ -205,9 +206,14 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 	var tags = map[string]string{
 		"Name": name,
 	}
+	var volumeTags = map[string]string{}
 	// add user defined tags
 	for k, v := range p.tags {
 		tags[k] = v
+	}
+	// add volume tags
+	for k, v := range p.volumeTags {
+		volumeTags[k] = v
 	}
 	if p.vpc == "" {
 		logr.Traceln("amazon: using default vpc, checking security groups")
@@ -270,6 +276,10 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 			{
 				ResourceType: aws.String("instance"),
 				Tags:         convertTags(tags),
+			},
+			{
+				ResourceType: aws.String("volume"),
+				Tags:         convertTags(volumeTags),
 			},
 		},
 		BlockDeviceMappings: []*ec2.BlockDeviceMapping{

--- a/app/drivers/amazon/option.go
+++ b/app/drivers/amazon/option.go
@@ -185,6 +185,11 @@ func WithVolumeSize(s int64) Option {
 		}
 	}
 }
+func WithVolumeTags(t map[string]string) Option {
+	return func(p *config) {
+		p.volumeTags = t
+	}
+}
 
 // WithVolumeType returns an option to set the volume type.
 func WithVolumeType(t string) Option {

--- a/app/poolfile/config.go
+++ b/app/poolfile/config.go
@@ -98,6 +98,7 @@ func ProcessPool(poolFile *config.PoolFile, runnerName string, passwords types.P
 				amazon.WithSubnet(a.Network.SubnetID),
 				amazon.WithUserData(a.UserData, a.UserDataPath),
 				amazon.WithVolumeSize(a.Disk.Size),
+				amazon.WithVolumeTags(a.Disk.Tags),
 				amazon.WithVolumeType(a.Disk.Type),
 				amazon.WithVolumeIops(a.Disk.Iops, a.Disk.Type),
 				amazon.WithKMSKeyID(a.Disk.KmsKeyID),

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -243,10 +243,11 @@ type (
 
 	// disk provides disk size and type.
 	disk struct {
-		Size     int64  `json:"size,omitempty" yaml:"size,omitempty"`
-		Type     string `json:"type,omitempty" yaml:"type,omitempty"`
-		Iops     int64  `json:"iops,omitempty" yaml:"iops,omitempty"`
-		KmsKeyID string `json:"kms_key_id,omitempty" yaml:"kms_key_id,omitempty"`
+		Tags     map[string]string `json:"tags,omitempty" yaml:"tags,omitempty"`
+		Size     int64             `json:"size,omitempty" yaml:"size,omitempty"`
+		Type     string            `json:"type,omitempty" yaml:"type,omitempty"`
+		Iops     int64             `json:"iops,omitempty" yaml:"iops,omitempty"`
+		KmsKeyID string            `json:"kms_key_id,omitempty" yaml:"kms_key_id,omitempty"`
 	}
 )
 


### PR DESCRIPTION
Field for adding tags to the aws volumes.
```
version: "1"
instances:
  - name: linux-amd64
    type: amazon
    spec:
      disk:
        tags: #new field
          volumekey: volumeValue
          key1: value2
        size: 100
        kms_key_id: 95294cb8-24d7-4994-998e-5850945171da
```
Here the volumes obtained by this pool will have the tags volumekey: volumeValue and key1: value2.
Tested with aws with encrypted and non encrypted volumes.

If you are adding new functionality, please provide evidence of the new functionality.
