### PR TITLE
feat: [CDE-828]: use configurable image for vms for gitspace

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -207,12 +207,17 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		p.size = opts.MachineType
 	}
 
+	imageName := p.image
+	if opts.VMImageConfig.ImageName != "" {
+		imageName = opts.VMImageConfig.ImageName
+	}
+
 	logr := logger.FromContext(ctx).
 		WithField("driver", types.Amazon).
 		WithField("ami", p.InstanceType()).
 		WithField("pool", opts.PoolName).
 		WithField("region", p.region).
-		WithField("image", p.image).
+		WithField("image", imageName).
 		WithField("size", p.size).
 		WithField("zone", p.availabilityZone).
 		WithField("hibernate", p.CanHibernate())
@@ -278,7 +283,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 	}
 
 	in := &ec2.RunInstancesInput{
-		ImageId:            aws.String(p.image),
+		ImageId:            aws.String(imageName),
 		InstanceType:       aws.String(p.size),
 		Placement:          &ec2.Placement{AvailabilityZone: aws.String(p.availabilityZone)},
 		MinCount:           aws.Int64(1),
@@ -410,7 +415,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		Provider:             types.Amazon, // this is driver, though its the old legacy name of provider
 		State:                types.StateCreated,
 		Pool:                 opts.PoolName,
-		Image:                p.image,
+		Image:                imageName,
 		Zone:                 p.availabilityZone,
 		Region:               p.region,
 		Size:                 p.size,

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -183,8 +183,19 @@ func (p *config) create(ctx context.Context, opts *types.InstanceCreateOpts, nam
 	if opts.MachineType != "" {
 		p.size = opts.MachineType
 	}
+
 	if opts.VMImageConfig.ImageName != "" {
-		p.image = buildImagePathFromTag(opts.VMImageConfig.ImageName, p.projectID)
+		// opts.VMImageConfig.ImageName can be of different formats.
+		// we can receive image in following 2 formats:
+		// Format #1: harness/vmimage: hosted-vm-ubuntu-2204-jammy-v20250508
+		// Format #2: projects/debian-cloud/global/images/debian-11-bullseye-v2025070
+		// isFullImagePath() method checks if given image in opts.VMImageConfig.ImageName is of Format #2 which can be
+		// directly used, else we convert Format #1 to Format #2 in buildImagePathFromTag() method.
+		if isFullImagePath(opts.VMImageConfig.ImageName) {
+			p.image = opts.VMImageConfig.ImageName
+		} else {
+			p.image = buildImagePathFromTag(opts.VMImageConfig.ImageName, p.projectID)
+		}
 	}
 
 	logr := logger.FromContext(ctx).

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -867,7 +867,7 @@ func (p *config) getZone(ctx context.Context, instance *types.Instance) (string,
 	return instance.Zone, nil
 }
 
-// setImage checks Image name in opts and it an image is sent in the request, it sets the image in config
+// setImage set image sent in the request to p.config . setImage() will not set image if imageName is empty
 func (p *config) setImage(opts *types.InstanceCreateOpts) {
 	if opts.VMImageConfig.ImageName == "" {
 		return

--- a/app/drivers/google/util.go
+++ b/app/drivers/google/util.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	letters       = "0123456789abcdefghijklmnopqrstuvwxyz"
-	maxSplitParts = 2
+	letters            = "0123456789abcdefghijklmnopqrstuvwxyz"
+	maxSplitParts      = 2
+	minImagePathSplits = 5
 )
 
 func randStringRunes(n int) (string, error) {
@@ -44,7 +45,7 @@ func buildImagePathFromTag(imageTag, projectID string) string {
 // projects/<project-name>/global/images/<image-tag>
 func isFullImagePath(imageName string) bool {
 	imageList := strings.Split(imageName, "/")
-	if len(imageList) < 5 {
+	if len(imageList) < minImagePathSplits {
 		return false
 	}
 

--- a/app/drivers/google/util.go
+++ b/app/drivers/google/util.go
@@ -40,6 +40,25 @@ func buildImagePathFromTag(imageTag, projectID string) string {
 	return imagePath + imageName
 }
 
+// isFullImagePath returns true if the image name contains full path ie. it is of the format:
+// projects/<project-name>/global/images/<image-tag>
+func isFullImagePath(imageName string) bool {
+	imageList := strings.Split(imageName, "/")
+	if len(imageList) < 5 {
+		return false
+	}
+
+	if imageList[0] != "projects" && imageList[2] != "global" && imageList[3] != "images" {
+		return false
+	}
+
+	if imageList[1] == "" || imageList[4] == "" {
+		return false
+	}
+
+	return true
+}
+
 func extractImageNameFromTag(tag string) string {
 	index := strings.Index(tag, ":")
 	if index == -1 {

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -380,7 +380,7 @@ func (m *Manager) Provision(
 			serverName,
 			ownerID,
 			resourceClass,
-			nil,
+			vmImageConfig,
 			true,
 			gitspaceAgentConfig,
 			storageConfig,


### PR DESCRIPTION
# What
* Add support to configure vm image from `/setup` request param
* add support to configure vm image from `/setup` request param for aws driver.
  * If image is not provided, we will use the image from pool.yaml 
* add support to directly send image path for gcp driver 

## Testing 
Created VM with image given in the request for aws ✅ 
* setup request contains `ami-0001c5332b86ed44b` while pool.yml contains `ami-084568db4383264d4` image 
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 11 18 39 PM" src="https://github.com/user-attachments/assets/fe7d6513-25bc-44ad-ae41-1ba53b7cc512" />

* VM is provisioned with `ami-0001c5332b86ed44b`
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 10 52 40 PM" src="https://github.com/user-attachments/assets/df70b045-355a-40c9-b223-b3f0269cad90" />
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 10 52 51 PM" src="https://github.com/user-attachments/assets/84a6eb4d-56e7-4f92-b653-4f2cc3786f38" />

Created VM with image given in the request for gcp ✅ 
* request with image `projects/debian-cloud/global/images/debian-11-bullseye-v20250709`
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 11 23 36 PM" src="https://github.com/user-attachments/assets/bb1a989c-1a6e-4ba0-b3d6-0774afdd4253" />

* VM successfully created
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 10 57 29 PM" src="https://github.com/user-attachments/assets/f309716c-4c98-4b00-bac2-455b61da69a2" />
<img width="1920" height="1080" alt="Screenshot 2025-07-14 at 10 57 58 PM" src="https://github.com/user-attachments/assets/fa2547e8-0f96-46de-902d-6aa34dc8ec37" />



# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
