### PR TITLE
feat: [CI-18029]: Added logs for GCP incase of success and fail init step

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -244,11 +244,7 @@ func HandleSetup(
 				r.VMImageConfig.ImageName,
 			).Inc()
 		}
-		internalLogger.WithField("account_id", GetAccountID(&r.Context, r.Tags)).
-			WithField("project_id", r.Context.ProjectID).
-			WithField("pipeline_id", r.Context.PipelineID).
-			WithField("stage_runtime_id", stageRuntimeID).
-			WithField("org_id", getOrgID(&r.Context, r.Tags)).
+		internalLogger.WithField("stage_runtime_id", stageRuntimeID).
 			Errorln("Init step failed")
 		return nil, "", fmt.Errorf("could not provision a VM from the pool: %w", poolErr)
 	}
@@ -291,11 +287,7 @@ func HandleSetup(
 		WithField("tried_pools", pools).
 		Traceln("VM setup is complete")
 
-	internalLogger.WithField("account_id", GetAccountID(&r.Context, r.Tags)).
-		WithField("project_id", r.Context.ProjectID).
-		WithField("pipeline_id", r.Context.PipelineID).
-		WithField("stage_runtime_id", stageRuntimeID).
-		WithField("org_id", getOrgID(&r.Context, r.Tags)).
+	internalLogger.WithField("stage_runtime_id", stageRuntimeID).
 		Infoln("Init step completed successfully")
 
 	return resp, selectedPoolDriver, nil

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -247,7 +247,6 @@ func HandleSetup(
 		internalLogger.WithField("account_id", GetAccountID(&r.Context, r.Tags)).
 			WithField("project_id", r.Context.ProjectID).
 			WithField("pipeline_id", r.Context.PipelineID).
-			WithField("execution_id", r.Context.RunSequence).
 			WithField("stage_runtime_id", stageRuntimeID).
 			WithField("org_id", getOrgID(&r.Context, r.Tags)).
 			Errorln("Init step failed")
@@ -295,7 +294,6 @@ func HandleSetup(
 	internalLogger.WithField("account_id", GetAccountID(&r.Context, r.Tags)).
 		WithField("project_id", r.Context.ProjectID).
 		WithField("pipeline_id", r.Context.PipelineID).
-		WithField("execution_id", r.Context.RunSequence).
 		WithField("stage_runtime_id", stageRuntimeID).
 		WithField("org_id", getOrgID(&r.Context, r.Tags)).
 		Infoln("Init step completed successfully")


### PR DESCRIPTION
## 🔧 CI-18029: Added Logging for GCP on Init Step

This change adds detailed logs to GCP for both **success** and **failure** scenarios during the init step.  
The following information will now be logged:

- `accountId`
- `buildId`
- `pipelineId`
- `orgId`
- `projectId`
- `stageRuntimeId`
- `taskId`
- `isRunner`

---

### ✅ On Init Step Success

<img width="1726" alt="Success Log UI" src="https://github.com/user-attachments/assets/9ebbab95-c605-4c03-bb89-dfbb9de494ce" />
<img width="1630" alt="Success Log Details" src="https://github.com/user-attachments/assets/b69f0642-eb52-4d80-a191-9e290ab7efb1" />

---

### ❌ On Init Step Failure

<img width="1723" alt="Failure Log UI" src="https://github.com/user-attachments/assets/cb0bf709-b067-4a56-af35-e10aa75a2cc7" />
<img width="1638" alt="Failure Log Details" src="https://github.com/user-attachments/assets/bfbe20bb-af26-4d3d-90a0-cf51ee49d932" />



