### PR TITLE
feat: [CI-18088]: enable authenticated Git operations (like push or f…

### DIFF
--- a/app/oshelp/oshelp.go
+++ b/app/oshelp/oshelp.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/dchest/uniuri"
+	"github.com/harness/lite-engine/engine/spec"
 
 	"github.com/drone/runner-go/shell/bash"
 	"github.com/drone/runner-go/shell/powershell"
@@ -63,6 +64,30 @@ func GetNetrc(os string) string {
 		return "_netrc"
 	default:
 		return ".netrc"
+	}
+}
+
+func GetNetrcFile(os string, env map[string]string) *spec.File {
+	netrcName := GetNetrc(os)
+
+	var path string
+	switch os {
+	case OSLinux:
+		path = fmt.Sprintf("/home/ubuntu/%s", netrcName)
+	case OSWindows:
+		path = fmt.Sprintf(`C:\Windows\system32\config\systemprofile\%s`, netrcName)
+	case OSMac:
+		path = fmt.Sprintf("/Users/anka/%s", netrcName)
+	default:
+		path = fmt.Sprintf("/root/%s", netrcName)
+	}
+	data := fmt.Sprintf("machine %s\nlogin %s\npassword %s\n", env["DRONE_NETRC_MACHINE"], env["DRONE_NETRC_USERNAME"], env["DRONE_NETRC_PASSWORD"])
+
+	return &spec.File{
+		Path:  path,
+		Mode:  777,
+		IsDir: false,
+		Data:  data,
 	}
 }
 

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -449,6 +449,12 @@ func handleSetup(
 		b := false
 		r.SetupRequest.MountDockerSocket = &b
 	}
+	if r.Envs["DRONE_PERSIST_CREDS"] == "true" {
+		r.SetupRequest.Files = append(
+			r.SetupRequest.Files,
+			oshelp.GetNetrcFile(instance.Platform.OS, r.Envs),
+		)
+	}
 
 	_, err = client.Setup(ctx, &r.SetupRequest)
 	if err != nil {


### PR DESCRIPTION
JIRA: https://harness.atlassian.net/browse/CI-18088
We want to enable authenticated Git operations (like push or fetch) in later Run steps of a pipeline.
The drone-git plugin already stores Git credentials in a .netrc file during the initial clone step.
Our goal is to share this .netrc file with all containers in the Pod.
To do this, we create an emptyDir volume (netrc-volume) that acts as shared storage.
An init container creates the .netrc file, which drone-git populates.
Each container mounts this volume so .netrc appears at the right paths (/root/.netrc and /home/drone/.netrc).
This allows seamless, reusable Git authentication across all steps without re-authentication.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
