### PR TITLE
feat: [CI-18607]: add info of pipeline build in VM metadata

### DIFF
--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -278,6 +278,30 @@ func (p *config) create(ctx context.Context, opts *types.InstanceCreateOpts, nam
 					Key:   p.userDataKey,
 					Value: googleapi.String(userData),
 				},
+				{
+					Key:   "harness-account-id",
+					Value: googleapi.String(opts.AccountID),
+				},
+				{
+					Key:   "harness-pool-name",
+					Value: googleapi.String(opts.PoolName),
+				},
+				{
+					Key:   "harness-runner-name",
+					Value: googleapi.String(opts.RunnerName),
+				},
+				{
+					Key:   "harness-resource-class",
+					Value: googleapi.String(opts.ResourceClass),
+				},
+				{
+					Key:   "harness-platform-os",
+					Value: googleapi.String(opts.Platform.OS),
+				},
+				{
+					Key:   "harness-platform-arch",
+					Value: googleapi.String(opts.Platform.Arch),
+				},
 			},
 		},
 		Disks: []*compute.AttachedDisk{


### PR DESCRIPTION

<img width="1384" height="618" alt="Screenshot 2025-08-11 at 9 09 47 AM" src="https://github.com/user-attachments/assets/2e03a349-bfb9-4dda-acb0-f04c9476888a" />

Added a Metadata of pipeline in VM Metadata, below field will be listed:
- harness-account-id
- harness-pool-name
- harness-runner-name
- harness-resource-class
- harness-platform-os
- harness-platform-arch

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
