### PR TITLE
feat: [CI-16639]: Add owner_id and resource_class labels to metrics for per account analytics

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -188,6 +188,7 @@ func HandleSetup(
 				metric.True,
 				strconv.FormatBool(poolManager.IsDistributed()),
 				owner,
+				r.ResourceClass,
 				r.VMImageConfig.ImageVersion,
 				r.VMImageConfig.ImageName,
 			).Inc()
@@ -217,6 +218,7 @@ func HandleSetup(
 			driver,
 			strconv.FormatBool(poolManager.IsDistributed()),
 			owner,
+			r.ResourceClass,
 			r.VMImageConfig.ImageVersion,
 			r.VMImageConfig.ImageName,
 		).Inc()
@@ -228,6 +230,7 @@ func HandleSetup(
 			strconv.FormatBool(poolManager.IsDistributed()),
 			"",
 			owner,
+			r.ResourceClass,
 			"",
 			r.VMImageConfig.ImageVersion,
 			r.VMImageConfig.ImageName,
@@ -241,6 +244,7 @@ func HandleSetup(
 				metric.False,
 				strconv.FormatBool(poolManager.IsDistributed()),
 				owner,
+				r.ResourceClass,
 				r.VMImageConfig.ImageVersion,
 				r.VMImageConfig.ImageName,
 			).Inc()
@@ -258,6 +262,7 @@ func HandleSetup(
 		strconv.FormatBool(poolManager.IsDistributed()),
 		instance.Zone,
 		owner,
+		r.ResourceClass,
 		instance.Address,
 		r.VMImageConfig.ImageVersion,
 		r.VMImageConfig.ImageName,

--- a/metric/builds.go
+++ b/metric/builds.go
@@ -26,11 +26,12 @@ type Metrics struct {
 }
 
 type label struct {
-	os     string
-	arch   string
-	state  string
-	poolID string
-	driver string
+	os      string
+	arch    string
+	state   string
+	poolID  string
+	driver  string
+	ownerID string
 }
 
 type Store struct {
@@ -74,7 +75,7 @@ func BuildCount() *prometheus.CounterVec {
 			Name: "harness_ci_pipeline_execution_total",
 			Help: "Total number of completed pipeline executions (failed + successful)",
 		},
-		[]string{"pool_id", "os", "arch", "driver", "distributed", "zone", "owner_id", "address", "image_version", "image_name"},
+		[]string{"pool_id", "os", "arch", "driver", "distributed", "zone", "owner_id", "resource_class", "address", "image_version", "image_name"},
 	)
 }
 
@@ -85,7 +86,7 @@ func FailedBuildCount() *prometheus.CounterVec {
 			Name: "harness_ci_pipeline_execution_errors_total",
 			Help: "Total number of pipeline executions which failed due to system errors",
 		},
-		[]string{"pool_id", "os", "arch", "driver", "distributed", "owner_id", "image_version", "image_name"},
+		[]string{"pool_id", "os", "arch", "driver", "distributed", "owner_id", "resource_class", "image_version", "image_name"},
 	)
 }
 
@@ -96,7 +97,7 @@ func RunningCount() *prometheus.GaugeVec {
 			Name: "harness_ci_pipeline_running_executions",
 			Help: "Total number of running executions",
 		},
-		[]string{"pool_id", "os", "arch", "driver", "state", "distributed"}, // state can be running, in_use, or hibernating
+		[]string{"pool_id", "os", "arch", "driver", "state", "distributed", "owner_id"}, // state can be running, in_use, or hibernating
 	)
 }
 
@@ -139,14 +140,14 @@ func (m *Metrics) updateRunningCount(ctx context.Context, metricStore *Store, wg
 		return
 	}
 	for _, i := range instances {
-		l := label{os: i.OS, arch: i.Arch, state: string(i.State), poolID: i.Pool, driver: string(i.Provider)}
+		l := label{os: i.OS, arch: i.Arch, state: string(i.State), poolID: i.Pool, driver: string(i.Provider), ownerID: i.OwnerID}
 		if i.OwnerID != "" {
 			m.RunningPerAccountCount.WithLabelValues(i.OwnerID, i.OS, strconv.FormatBool(metricStore.Distributed)).Inc()
 		}
 		d[l]++
 	}
 	for k, v := range d {
-		m.RunningCount.WithLabelValues(k.poolID, k.os, k.arch, k.driver, k.state, strconv.FormatBool(metricStore.Distributed)).Set(float64(v))
+		m.RunningCount.WithLabelValues(k.poolID, k.os, k.arch, k.driver, k.state, strconv.FormatBool(metricStore.Distributed), k.ownerID).Set(float64(v))
 	}
 }
 
@@ -157,7 +158,7 @@ func PoolFallbackCount() *prometheus.CounterVec {
 			Name: "harness_ci_pipeline_pool_fallbacks",
 			Help: "Total number of fallbacks triggered on the pool",
 		},
-		[]string{"pool_id", "os", "arch", "driver", "success", "distributed", "owner_id", "image_version", "image_name"}, // success is true/false depending on whether fallback happened successfully
+		[]string{"pool_id", "os", "arch", "driver", "success", "distributed", "owner_id", "resource_class", "image_version", "image_name"}, // success is true/false depending on whether fallback happened successfully
 	)
 }
 


### PR DESCRIPTION
## Summary

- Added `owner_id` and `resource_class` labels to **static metrics**:
  - `BuildCount`
  - `FailedBuildCount`  
  for historical tracking.
- Added `owner_id` label to **dynamic metrics**:
  - `RunningCount`  
  for real-time resource utilization tracking.

---
### Testing images for the same
<img width="1728" height="998" alt="Screenshot 2025-08-12 at 2 27 29 PM" src="https://github.com/user-attachments/assets/e7fbe283-2543-49b6-a51b-28a59b8c648b" />
<img width="1728" height="990" alt="Screenshot 2025-08-12 at 2 27 44 PM" src="https://github.com/user-attachments/assets/38cc69ba-50db-4ecc-9929-64ece7118983" />
<img width="1728" height="996" alt="Screenshot 2025-08-12 at 2 27 55 PM" src="https://github.com/user-attachments/assets/10f7fcff-6b51-4674-9600-9f42c904b7aa" />
<img width="1728" height="992" alt="Screenshot 2025-08-12 at 1 05 54 PM" src="https://github.com/user-attachments/assets/9a839dcd-7628-48b7-9bdc-62866cdbdd59" />
<img width="1728" height="996" alt="Screenshot 2025-08-12 at 1 08 30 PM" src="https://github.com/user-attachments/assets/acf2721d-b946-41a5-a233-1a3e1fa97c2a" />
<img width="1728" height="1004" alt="Screenshot 2025-08-12 at 1 08 41 PM" src="https://github.com/user-attachments/assets/77c75fb2-eff7-404c-b9ce-b53efca59cba" />

