### PR TITLE
feat: [CI-18793]: Updated metrics to capture correct wait time and failed counts

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -158,8 +158,8 @@ func HandleSetup(
 		setupTime = time.Since(st)
 		metrics.WaitDurationCount.WithLabelValues(
 			pool,
-			instance.OS,
-			instance.Arch,
+			platform.OS,
+			platform.Arch,
 			poolDriver,
 			metric.ConvertBool(fallback),
 			strconv.FormatBool(poolManager.IsDistributed()),

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -196,8 +196,6 @@ func HandleSetup(
 		break
 	}
 
-	// amount of time it took to provision an instance
-
 	// If a successful fallback happened and we have an instance setup, record it
 	if foundPool && instance != nil { // check for instance != nil just in case
 		// add an entry in stage pool mapping if instance was created.


### PR DESCRIPTION
## Summary of Changes
- **`harness_ci_pipeline_execution_errors_total`**
  - Now records **which pool** the failure occurred in.
  - Previously it only recorded the **requested pool**.
  - Updated to **capture all failed pools**, not just one.

- **`harness_ci_runner_wait_duration_seconds`**
  - Fixed to record the **actual wait time**.
  - Previously it was capturing the **overall  time** instead.

## Screenshots
Wait count of different pools in case of fallback 
<img width="1728" height="1095" alt="Screenshot 2025-08-28 at 4 08 52 PM" src="https://github.com/user-attachments/assets/fd9612e4-7429-4346-b38d-0aa99b905147" />
Failed count of failed pools
<img width="1728" height="995" alt="Screenshot 2025-08-28 at 4 16 26 PM" src="https://github.com/user-attachments/assets/9e6f016e-2e98-498b-bd91-42fce6c168cb" />
<img width="1721" height="991" alt="Screenshot 2025-08-21 at 9 39 47 PM" src="https://github.com/user-attachments/assets/870c8f06-fa00-4b21-8575-c320aeb0062b" />
<img width="1728" height="995" alt="Screenshot 2025-08-22 at 10 27 31 AM" src="https://github.com/user-attachments/assets/07353f82-2b2b-4d28-a5b9-bdd6334e3100" />
<img width="1727" height="997" alt="Screenshot 2025-08-22 at 10 27 56 AM" src="https://github.com/user-attachments/assets/e1e230c1-cdc4-4bee-84b3-914893c8e7b2" />
<img width="1727" height="1001" alt="Screenshot 2025-08-22 at 10 28 58 AM" src="https://github.com/user-attachments/assets/7b316dae-5699-4680-83d1-cc2d7dadbdf2" />
<img width="1727" height="990" alt="Screenshot 2025-08-22 at 11 06 04 AM" src="https://github.com/user-attachments/assets/21553207-99d1-498d-b193-65e029b1ef2d" />
<img width="1725" height="993" alt="Screenshot 2025-08-22 at 11 17 19 AM" src="https://github.com/user-attachments/assets/b5c76e09-c8ca-4ea0-8e26-8a1286a31d81" />



# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
