### PR TITLE
fix: [CI-17303]: Add ignite wait check in poststop hook

### DIFF
--- a/app/drivers/nomad/linux_virtualizer.go
+++ b/app/drivers/nomad/linux_virtualizer.go
@@ -162,6 +162,10 @@ func (lv *LinuxVirtualizer) GetInitJob(vm, nodeID, userData, machinePassword, de
 								exit 1
 							`, ignitePath, vm, vm, vm)},
 						},
+						Lifecycle: &api.TaskLifecycle{
+							Sidecar: false,
+							Hook:    "poststop",
+						},
 					},
 					{
 						Name:      "ignite_exec",


### PR DESCRIPTION
Add ignite wait check in poststop hook. This only runs the task once all the main tasks are completed.
