### PR TITLE
feat: [CDE-1026]: Gitspace VM name and infra reset updates

### DIFF
--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -1085,7 +1085,8 @@ func (m *Manager) processExistingInstance(
 		} else {
 			inst := common.BuildInstanceFromRequest(*instanceInfo)
 			if isMarkedForInfraReset {
-				destroyInstanceErr := pool.Driver.Destroy(ctx, []*types.Instance{inst})
+				storageCleanupType := storage.Detach
+				destroyInstanceErr := pool.Driver.DestroyInstanceAndStorage(ctx, []*types.Instance{inst}, &storageCleanupType)
 				if destroyInstanceErr != nil {
 					logrus.Warnf(
 						"failed to destroy instance %s: %v",


### PR DESCRIPTION
- Call DestroyInstanceAndStorage to wait for instance deletion
- Don't use gitspace config identifier as the VM name. Use it just as a label

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
