### PR TITLE
feat: [CI-19013]: Added vm tags for aws similar to gcp

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -238,6 +238,12 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 	var name = getInstanceName(opts.RunnerName, opts.PoolName, opts.GitspaceOpts.GitspaceConfigIdentifier)
 	var tags = map[string]string{
 		"Name": name,
+		"harness-account-id":     opts.AccountID,
+		"harness-pool-name":      opts.PoolName,
+		"harness-runner-name":    opts.RunnerName,
+		"harness-resource-class": opts.ResourceClass,
+		"harness-platform-os":    opts.Platform.OS,
+		"harness-platform-arch":  opts.Platform.Arch,
 	}
 	var volumeTags = map[string]string{}
 	// add user defined tags

--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -245,6 +245,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 		"harness-platform-os":    opts.Platform.OS,
 		"harness-platform-arch":  opts.Platform.Arch,
 	}
+
 	var volumeTags = map[string]string{}
 	// add user defined tags
 	for k, v := range p.tags {

--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -237,7 +237,7 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (in
 
 	var name = getInstanceName(opts.RunnerName, opts.PoolName, opts.GitspaceOpts.GitspaceConfigIdentifier)
 	var tags = map[string]string{
-		"Name": name,
+		"Name":                   name,
 		"harness-account-id":     opts.AccountID,
 		"harness-pool-name":      opts.PoolName,
 		"harness-runner-name":    opts.RunnerName,


### PR DESCRIPTION
### Summary
Added tags for AWS VM instances to improve debugging and provide better visibility.  

**Tags added:**
- `harness-account-id`
- `harness-pool-name`
- `harness-runner-name`
- `harness-resource-class`
- `harness-platform-os`
- `harness-platform-arch`

These tags will now be visible on the VM after provisioning, making it easier to trace and debug issues.  

**Screenshots:**
<img width="1728" height="988" alt="Screenshot 2025-09-15 at 10 10 54 PM" src="https://github.com/user-attachments/assets/8e683762-1fb3-47ff-b667-e7348703fc22" />
<img width="1724" height="983" alt="Screenshot 2025-09-15 at 10 10 44 PM" src="https://github.com/user-attachments/assets/86be000c-c276-4054-a104-9b59153c40ea" />

---

# Commit Checklist

Thank you for creating a pull request! To help us review and merge, please ensure that your PR adheres to the following:

## The Basics
- [ ] Added/updated unit tests (if applicable)  
- [ ] Updated documentation (if applicable)  
- [ ] Verified functionality locally or via screenshots/logs  
