### PR TITLE
[feat]: [CI-19068]: Reduce Init Time Incase of Fallback

### DIFF
--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -127,7 +127,7 @@ func (p *config) Ping(ctx context.Context) error {
 
 // Create creates a VM using port forwarding inside a bare metal machine assigned by nomad.
 // This function is idempotent - any errors in between will cleanup the created VMs.
-func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*types.Instance, error) { //nolint:gocyclo
+func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*types.Instance, error) { //nolint:gocyclo,funlen
 	vm := strings.ToLower(random(20)) //nolint:gomnd
 	class := ""
 	for k, v := range p.enablePinning {

--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -197,18 +197,24 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 
 	_, _, err = p.client.Jobs().Register(resourceJob, nil)
 	if err != nil {
-		defer p.getAllocationsForJob(logr, resourceJobID)
+		defer func() {
+			go p.getAllocationsForJob(logr, resourceJobID)
+		}()
 		return nil, fmt.Errorf("scheduler: could not register job, err: %w", err)
 	}
 	// If resources don't become available in `p.nomadConfig.ResourceJobTimeout`, we fail the step
 	job, err := p.pollForJob(ctx, resourceJobID, logr, p.nomadConfig.ResourceJobTimeout, true, []JobStatus{Running, Dead})
 	if err != nil {
-		defer p.getAllocationsForJob(logr, resourceJobID)
+		defer func() {
+			go p.getAllocationsForJob(logr, resourceJobID)
+		}()
 		return nil, fmt.Errorf("scheduler: could not find a node with available resources, err: %w", err)
 	}
 
 	if job == nil || isTerminal(job) {
-		defer p.getAllocationsForJob(logr, resourceJobID)
+		defer func() {
+			go p.getAllocationsForJob(logr, resourceJobID)
+		}()
 		return nil, fmt.Errorf("scheduler: resource job reached terminal state before starting")
 	}
 	logr.Infoln("scheduler: found a node with available resources")
@@ -216,7 +222,9 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	// get the machine details where the resource job was allocated
 	ip, id, liteEngineHostPort, gitspacesPorts, err := p.fetchMachine(logr, resourceJobID)
 	if err != nil {
-		defer p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		defer func() {
+			go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		}()
 		return nil, err
 	}
 
@@ -240,7 +248,9 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	} else {
 		initJob, initJobID, initTaskGroup, err = p.virtualizer.GetInitJob(vm, id, p.userData, p.machinePassword, p.vmImage, vmImageConfig, liteEngineHostPort, resource, opts, gitspacesPortMappings, opts.Timeout) //nolint
 		if err != nil {
-			defer p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+			defer func() {
+				go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+			}()
 			return nil, err
 		}
 	}
@@ -257,7 +267,9 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 
 	labelsBytes, marshalErr := json.Marshal(opts.Labels)
 	if marshalErr != nil {
-		defer p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		defer func() {
+			go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		}()
 		return nil, fmt.Errorf("scheduler: could not marshal labels: %v, err: %w", opts.Labels, marshalErr)
 	}
 	instance := &types.Instance{
@@ -286,24 +298,30 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	logr.Infoln("scheduler: submitting VM creation job")
 	_, _, err = p.client.Jobs().Register(initJob, nil)
 	if err != nil {
-		defer p.getAllocationsForJob(logr, initJobID)
-		defer p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		defer func() {
+			go p.getAllocationsForJob(logr, initJobID)
+			go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
+		}()
 		return nil, fmt.Errorf("scheduler: could not register job, err: %w ip: %s, resource_job_id: %s, init_job_id: %s, vm: %s", err, ip, resourceJobID, initJobID, vm)
 	}
 	logr.Infoln("scheduler: successfully submitted init job, started polling for job status")
 	_, err = p.pollForJob(ctx, initJobID, logr, p.virtualizer.GetInitJobTimeout(vmImageConfig), true, []JobStatus{Dead})
 	if err != nil {
-		defer p.getAllocationsForJob(logr, initJobID)
-		// Destroy the VM if it's in a partially created state
-		defer p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		defer func() {
+			go p.getAllocationsForJob(logr, initJobID)
+			// Destroy the VM if it's in a partially created state
+			go p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		}()
 		return nil, fmt.Errorf("scheduler: could not poll for init job status, failed with error: %s on ip: %s, resource_job_id: %s, init_job_id: %s, vm: %s", err, ip, resourceJobID, initJobID, vm)
 	}
 
 	// Make sure all subtasks in the init job passed
 	err = p.checkTaskGroupStatus(initJobID, initTaskGroup)
 	if err != nil {
-		defer p.getAllocationsForJob(logr, initJobID)
-		defer p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		defer func() {
+			go p.getAllocationsForJob(logr, initJobID)
+			go p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		}()
 		return nil, fmt.Errorf("scheduler: init job failed with error: %s on ip: %s, resource_job_id: %s, init_job_id: %s, vm: %s", err, ip, resourceJobID, initJobID, vm)
 	}
 	logr.Infoln("scheduler: Successfully submitted polled job")
@@ -311,12 +329,16 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	// Check status of the resource job. If it reached a terminal state, destroy the VM and remove the resource job
 	job, _, err = p.client.Jobs().Info(resourceJobID, &api.QueryOptions{})
 	if err != nil {
-		defer p.getAllocationsForJob(logr, resourceJobID)
+		defer func() {
+			go p.getAllocationsForJob(logr, resourceJobID)
+		}()
 		return nil, fmt.Errorf("scheduler: could not query resource job, err: %w, resource_job_id: %s, init_job_id: %s, vm: %s", err, resourceJobID, initJobID, vm)
 	}
 	if job == nil || isTerminal(job) {
-		defer p.getAllocationsForJob(logr, resourceJobID)
-		defer p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		defer func() {
+			go p.getAllocationsForJob(logr, resourceJobID)
+			go p.Destroy(context.Background(), []*types.Instance{instance}) //nolint:errcheck
+		}()
 		return nil, fmt.Errorf("scheduler: resource job reached unexpected terminal status, removing VM, resource_job_id: %s, init_job_id: %s, vm: %s", resourceJobID, initJobID, vm)
 	}
 

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -355,7 +355,7 @@ type EnvConfig struct {
 		ResourceJobTimeout      time.Duration `envconfig:"NOMAD_RESOURCE_JOB_TIMEOUT" default:"2m"`
 		BYOIInitTimeout         time.Duration `envconfig:"NOMAD_BYOI_INIT_TIMEOUT" default:"15m"`
 		InitTimeout             time.Duration `envconfig:"NOMAD_INIT_TIMEOUT" default:"1m"`
-		DestroyTimeout          time.Duration `envconfig:"NOMAD_DESTROY_TIMEOUT" default:"3m"`
+		DestroyTimeout          time.Duration `envconfig:"NOMAD_DESTROY_TIMEOUT" default:"1m"`
 		GlobalAccount           string        `envconfig:"NOMAD_GLOBAL_ACCOUNT" default:"PAID_POOL"`
 		DestroyRetryAttempts    int           `envconfig:"NOMAD_DESTROY_RETRY_ATTEMPTS" default:"1"`
 		MinNomadCPUMhz          int           `envconfig:"NOMAD_MIN_CPU_MHZ" default:"40"`


### PR DESCRIPTION
If the baremetal init fails we try to run a destroy job for the vm. We poll for the job status for 3 minutes for that. Currently that logic is sync and blocks the thread from trying to initialize the vm in the fallback pool. 2 things I am doing to speed things up

1. Reduce timeout from 3m to 1m
2. Make the cleanup logic async so it doesnt block the fallback logic



Screenshot showing there is now no time diff between nomad init failure and gcp init start

<img width="1651" height="164" alt="Screenshot 2025-10-01 at 2 20 18 PM" src="https://github.com/user-attachments/assets/f9b4e729-4d6e-4076-8801-52d49920dd80" />


