### PR TITLE
[feat]: [CI-19223]: Add metrics and log for total init time

### DIFF
--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -73,6 +73,7 @@ func HandleSetup(
 	poolManager drivers.IManager,
 	metrics *metric.Metrics,
 ) (*SetupVMResponse, string, error) {
+	initStartTime := time.Now()
 	stageRuntimeID := r.ID
 	if stageRuntimeID == "" {
 		return nil, "", errors.NewBadRequestError("mandatory field 'id' in the request body is empty")
@@ -237,7 +238,7 @@ func HandleSetup(
 			WithField("selected_pool", selectedPool).
 			WithField("requested_pool", r.PoolID).
 			WithField("instance_address", instance.Address).
-			Tracef("init time for vm setup is %.2fs", setupTime.Seconds())
+			Tracef("init time for vm setup in pool %s is %.2fs", selectedPool, setupTime.Seconds())
 	} else {
 		metrics.BuildCount.WithLabelValues(
 			r.PoolID,
@@ -312,6 +313,27 @@ func HandleSetup(
 
 	internalLogr.WithField("stage_runtime_id", stageRuntimeID).
 		Traceln("Init step completed successfully")
+
+	totalInitTime := time.Since(initStartTime)
+	internalLogr.WithField("os", instance.OS).
+		WithField("arch", instance.Arch).
+		WithField("selected_pool", selectedPool).
+		WithField("requested_pool", r.PoolID).
+		WithField("instance_address", instance.Address).
+		Tracef("total init time for vm setup %s is %.2fs", totalInitTime.Seconds())
+	metrics.TotalVMInitDurationCount.WithLabelValues(
+		selectedPool,
+		platform.OS,
+		platform.Arch,
+		selectedPoolDriver,
+		metric.ConvertBool(fallback),
+		strconv.FormatBool(poolManager.IsDistributed()),
+		owner,
+		r.VMImageConfig.ImageVersion,
+		r.VMImageConfig.ImageName,
+		strconv.FormatBool(warmed),
+		strconv.FormatBool(hibernated),
+	).Observe(totalInitTime.Seconds())
 
 	return resp, selectedPoolDriver, nil
 }

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -320,7 +320,7 @@ func HandleSetup(
 		WithField("selected_pool", selectedPool).
 		WithField("requested_pool", r.PoolID).
 		WithField("instance_address", instance.Address).
-		Tracef("total init time for vm setup %s is %.2fs", totalInitTime.Seconds())
+		Tracef("total init time for vm setup is %.2fs", totalInitTime.Seconds())
 	metrics.TotalVMInitDurationCount.WithLabelValues(
 		selectedPool,
 		platform.OS,

--- a/metric/builds.go
+++ b/metric/builds.go
@@ -350,7 +350,7 @@ func RegisterMetrics() *Metrics {
 	cpuPercentile := CPUPercentile()
 	memoryPercentile := MemoryPercentile()
 	errorCount := ErrorCount()
-	prometheus.MustRegister(buildCount, failedBuildCount, runningCount, runningPerAccountCount, poolFallbackCount, waitDurationCount, totalVMInitDurationCount, cpuPercentile, memoryPercentile, errorCount, warmPoolCount)
+	prometheus.MustRegister(buildCount, failedBuildCount, runningCount, runningPerAccountCount, poolFallbackCount, waitDurationCount, totalVMInitDurationCount, cpuPercentile, memoryPercentile, errorCount, warmPoolCount) //nolint:lll
 	return &Metrics{
 		BuildCount:               buildCount,
 		FailedCount:              failedBuildCount,


### PR DESCRIPTION
Currently we only have logs and metrics for init time per pool. This is not reflective of what the user sees when there are fallbacks since init request goes to multiple pool. I have added a new grafana metrics and logging for total init time for a VM 