### PR TITLE
Add SKU to PublicIPAddress parameters

### DIFF
--- a/app/drivers/azure/util.go
+++ b/app/drivers/azure/util.go
@@ -139,6 +139,9 @@ func (c *config) createPublicIP(ctx context.Context, publicIPName string) (*armn
 	parameters := armnetwork.PublicIPAddress{
 		Location: to.Ptr(c.location),
 		Zones:    c.zones,
+		SKU: &armnetwork.PublicIPAddressSKU{
+			Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
+		},  
 		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic), // Static or Dynamic
 		},


### PR DESCRIPTION
This pull request makes a targeted improvement to the Azure driver by specifying the SKU for created public IP addresses. This change ensures that all public IPs are created with the "Standard" SKU, which provides enhanced reliability and features compared to the default.

Azure public IP configuration:

* Updated the `createPublicIP` method in `util.go` to set the `SKU` property to `Standard` when creating a new public IP address.

To replicated that problem you need to use:

- Image: 
    * docker run -v /runner:/runner -p 3000:3000 drone/drone-runner-aws:1.0.0-rc.233 delegate --pool /runner/pool.yml
   * or docker run -v /runner:/runner -p 3000:3000 drone/drone-runner-aws:latest delegate --pool /runner/pool.yml
   
- For testing i just generate a new image that can be use to validate: 
  * docker run -v /runner:/runner -p 3000:3000 idasilva6/drone-runner-aws:v1.0.0  delegate --pool /runner/pool.yml

The pull configurantion that i used was:
```
version: "1"
instances:
  - name: ubuntu-azure-pool
    default: true
    type: azure
    pool: 1
    limit: 1
    platform:
      os: linux
      arch: amd64
    spec:
      account:
        client_id:  ## Required for the runner to be able to create new VMs.
        client_secret: ## Required for the runner to be able to create new VMs.
        subscription_id:  ## Required for the runner to be able to create new VMs.
        tenant_id:  ## Required for the runner to be able to create new VMs.
      location: brazilsouth  ## To minimize latency, use the same region as your Azure VM.
      size: Standard_E2s_v3
      tags:
        tagName: tag
      resource_group: harness-delegate-selfhosted_group
      image: ## Azure VM image specs to use for build VMs.
        username: azureuser
        password: AzurePass2026!Harness
        publisher: canonical
        offer: ubuntu-24_04-lts
        sku: server
        version: latest
```
Azure update:

1. https://azure.microsoft.com/en-us/updates?id=upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired


Issue: https://github.com/drone-runners/drone-runner-aws/issues/743