### PR TITLE
feat: [CI-22008]: Track instance source to prevent over-provisioning from predictor VMs

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -388,22 +388,31 @@ func (d *DistributedManager) provisionFromPool(
 				WithField("instance_id", inst.ID).
 				WithField("hotpool", true).
 				WithField("variant_id", candidateVariantID).
+				WithField("source", string(inst.Source)).
 				Traceln("provision: claimed hotpool instance")
 
-			// Backfill with empty Zones so round-robin selects the zone,
-			// rather than pinning to the consumed instance's zone which
-			// causes uneven distribution over time.
-			d.setupInstanceAsync(ctx, inst.Pool, inst.RunnerName, &types.SetupInstanceParams{
-				ImageName:            inst.Image,
-				NestedVirtualization: inst.EnableNestedVirtualization,
-				GPU:                  inst.GPU,
-				MachineType:          inst.Size,
-				Hibernate:            inst.IsHibernated,
-				VariantID:            inst.VariantID,
-				DiskSize:             setupParams.DiskSize,
-				DiskType:             setupParams.DiskType,
-				ResourceClass:        setupParams.ResourceClass,
-			})
+			// Only replenish pool-sourced instances. Predictor-created instances
+			// are managed by the scaler and should not be backfilled.
+			if shouldReplenishInstance(inst) {
+				d.setupInstanceAsync(ctx, inst.Pool, inst.RunnerName, &types.SetupInstanceParams{
+					ImageName:            inst.Image,
+					NestedVirtualization: inst.EnableNestedVirtualization,
+					GPU:                  inst.GPU,
+					MachineType:          inst.Size,
+					Hibernate:            inst.IsHibernated,
+					VariantID:            inst.VariantID,
+					DiskSize:             setupParams.DiskSize,
+					DiskType:             setupParams.DiskType,
+					ResourceClass:        setupParams.ResourceClass,
+					Source:               types.InstanceSourcePool,
+				})
+			} else {
+				logger.FromContext(ctx).
+					WithField("pool", poolName).
+					WithField("instance_id", inst.ID).
+					WithField("source", string(inst.Source)).
+					Infoln("provision: skipping replenishment for non-pool instance")
+			}
 			capacity = &types.CapacityReservation{
 				InstanceID: inst.ID,
 				PoolName:   poolName,
@@ -415,6 +424,7 @@ func (d *DistributedManager) provisionFromPool(
 	// set the variant ID to the first variant in the list
 	variantID = variantsToTry[0]
 	setupParams.VariantID = variantID
+	setupParams.Source = types.InstanceSourceOnDemand
 
 	// Case 3: No available hotpool instance across any variant → create new (using first variant's config)
 	logger.FromContext(ctx).
@@ -445,6 +455,13 @@ func (d *DistributedManager) provisionFromPool(
 		return nil, nil, false, variantID, fmt.Errorf("provision: failed to create instance: %w", err)
 	}
 	return inst, capacity, false, variantID, nil
+}
+
+// shouldReplenishInstance returns true if the claimed instance should be replenished.
+// Only pool-sourced instances are replenished. Predictor-sourced instances are managed
+// by the scaler, and on-demand instances are one-off.
+func shouldReplenishInstance(inst *types.Instance) bool {
+	return inst.Source == types.InstanceSourcePool
 }
 
 // filterVariants returns all matching variants in priority order based on provisionParams criteria.

--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -280,6 +280,7 @@ func (d *DistributedManager) provisionFromReservedCapacity(
 		_ = d.DestroyCapacity(ctx, reservedCapacity)
 		reservedCapacity = nil
 	}
+	setupParams.Source = types.InstanceSourceOnDemand
 	inst, _, err := d.setupInstance(ctx,
 		pool,
 		tlsServerName,

--- a/app/drivers/distributed_manager_test.go
+++ b/app/drivers/distributed_manager_test.go
@@ -895,3 +895,46 @@ func TestApplyVariantToSetupParams(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldReplenishInstance(t *testing.T) {
+	tests := []struct {
+		name   string
+		source types.InstanceSource
+		want   bool
+	}{
+		{
+			name:   "pool source should replenish",
+			source: types.InstanceSourcePool,
+			want:   true,
+		},
+		{
+			name:   "predictor source should not replenish",
+			source: types.InstanceSourcePredictor,
+			want:   false,
+		},
+		{
+			name:   "ondemand source should not replenish",
+			source: types.InstanceSourceOnDemand,
+			want:   false,
+		},
+		{
+			name:   "empty source should not replenish",
+			source: "",
+			want:   false,
+		},
+		{
+			name:   "unknown source should not replenish",
+			source: types.InstanceSourceUnknown,
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := &types.Instance{Source: tt.source}
+			got := shouldReplenishInstance(inst)
+			if got != tt.want {
+				t.Errorf("shouldReplenishInstance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/drivers/provisioner.go
+++ b/app/drivers/provisioner.go
@@ -326,6 +326,8 @@ func (m *Manager) setupInstance(
 		inst.VariantID = defaultVariantID
 	}
 
+	inst.Source = resolveInstanceSource(setupParams)
+
 	if inst.Labels == nil {
 		labelsBytes, marshalErr := json.Marshal(map[string]string{"retain": "false"})
 		if marshalErr != nil {
@@ -464,4 +466,12 @@ func vmImageConfigFromSetupParams(params *types.SetupInstanceParams) *spec.VMIma
 	return &spec.VMImageConfig{
 		ImageName: params.ImageName,
 	}
+}
+
+// resolveInstanceSource returns the instance source from setupParams, defaulting to pool.
+func resolveInstanceSource(params *types.SetupInstanceParams) types.InstanceSource {
+	if params != nil && params.Source != "" {
+		return params.Source
+	}
+	return types.InstanceSourcePool
 }

--- a/app/drivers/provisioner_source_test.go
+++ b/app/drivers/provisioner_source_test.go
@@ -1,0 +1,49 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+func TestSetupInstanceParams_SourcePassthrough(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   *types.SetupInstanceParams
+		expected types.InstanceSource
+	}{
+		{
+			name:     "pool source",
+			params:   &types.SetupInstanceParams{Source: types.InstanceSourcePool},
+			expected: types.InstanceSourcePool,
+		},
+		{
+			name:     "predictor source",
+			params:   &types.SetupInstanceParams{Source: types.InstanceSourcePredictor},
+			expected: types.InstanceSourcePredictor,
+		},
+		{
+			name:     "ondemand source",
+			params:   &types.SetupInstanceParams{Source: types.InstanceSourceOnDemand},
+			expected: types.InstanceSourceOnDemand,
+		},
+		{
+			name:     "empty source defaults to pool",
+			params:   &types.SetupInstanceParams{},
+			expected: types.InstanceSourcePool,
+		},
+		{
+			name:     "nil params defaults to pool",
+			params:   nil,
+			expected: types.InstanceSourcePool,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveInstanceSource(tt.params)
+			if got != tt.expected {
+				t.Errorf("resolveInstanceSource() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/app/scheduler/jobs/scaler.go
+++ b/app/scheduler/jobs/scaler.go
@@ -337,7 +337,7 @@ func (s *Scaler) scaleDown(
 		PoolName:     poolName,
 		VariantID:    variantID,
 		ImageName:    imageName,
-		PreferSource: types.InstanceSourcePredictor,
+		FilterSource: types.InstanceSourcePredictor,
 	}
 
 	allowedStates := []types.InstanceState{types.StateCreated, types.StateHibernating}

--- a/app/scheduler/jobs/scaler.go
+++ b/app/scheduler/jobs/scaler.go
@@ -277,10 +277,12 @@ func (s *Scaler) scaleUp(
 		setupParams := &types.SetupInstanceParams{
 			VariantID: variantID,
 			ImageName: imageName,
+			Source:    types.InstanceSourcePredictor,
 		}
 		if params != nil {
 			paramsCopy := *params
 			paramsCopy.VariantID = variantID
+			paramsCopy.Source = types.InstanceSourcePredictor
 			if imageName != "" {
 				paramsCopy.ImageName = imageName
 			}
@@ -332,9 +334,10 @@ func (s *Scaler) scaleDown(
 	// Use FindAndClaim to atomically claim instances for termination
 	// This avoids race conditions with other processes
 	queryParams := &types.QueryParams{
-		PoolName:  poolName,
-		VariantID: variantID,
-		ImageName: imageName,
+		PoolName:     poolName,
+		VariantID:    variantID,
+		ImageName:    imageName,
+		PreferSource: types.InstanceSourcePredictor,
 	}
 
 	allowedStates := []types.InstanceState{types.StateCreated, types.StateHibernating}

--- a/app/scheduler/jobs/scaler_test.go
+++ b/app/scheduler/jobs/scaler_test.go
@@ -110,6 +110,38 @@ func (m *MockInstanceStore) FindAndClaim(
 	ctx context.Context, params *types.QueryParams, newState types.InstanceState,
 	allowedStates []types.InstanceState, updateStartTime bool,
 ) (*types.Instance, error) {
+	isAllowed := func(state types.InstanceState) bool {
+		for _, s := range allowedStates {
+			if s == state {
+				return true
+			}
+		}
+		return false
+	}
+
+	matches := func(inst *types.Instance) bool {
+		return inst.Pool == params.PoolName && isAllowed(inst.State) &&
+			(params.VariantID == "" || inst.VariantID == params.VariantID) &&
+			(params.ImageName == "" || inst.Image == params.ImageName)
+	}
+
+	// First pass: find instances matching preferred source
+	if params.PreferSource != "" {
+		for i, inst := range m.instances {
+			if matches(inst) && inst.Source == params.PreferSource {
+				m.instances[i].State = newState
+				return m.instances[i], nil
+			}
+		}
+	}
+
+	// Second pass: any matching instance
+	for i, inst := range m.instances {
+		if matches(inst) {
+			m.instances[i].State = newState
+			return m.instances[i], nil
+		}
+	}
 	return nil, nil
 }
 
@@ -591,6 +623,16 @@ func TestScaler_ScaleUp(t *testing.T) {
 		if job.RunnerName != "" {
 			t.Errorf("expected runner name to be empty (so any runner can process), got %q", job.RunnerName)
 		}
+		// Verify source is set to predictor
+		if job.JobParams != nil {
+			var params types.SetupInstanceParams
+			if err := json.Unmarshal(*job.JobParams, &params); err != nil {
+				t.Fatalf("failed to unmarshal job params: %v", err)
+			}
+			if params.Source != types.InstanceSourcePredictor {
+				t.Errorf("expected Source=predictor in scaleUp job, got %q", params.Source)
+			}
+		}
 	}
 }
 
@@ -749,13 +791,16 @@ func TestScaler_WithVariants(t *testing.T) {
 		t.Errorf("expected 5 setup instance jobs, got %d", len(setupJobs))
 	}
 
-	// Count jobs by variant
+	// Count jobs by variant and verify source
 	variantCounts := make(map[string]int)
 	for _, job := range setupJobs {
 		if job.JobParams != nil {
 			var params types.SetupInstanceParams
 			if err := json.Unmarshal(*job.JobParams, &params); err == nil {
 				variantCounts[params.VariantID]++
+				if params.Source != types.InstanceSourcePredictor {
+					t.Errorf("expected Source=predictor for variant %q, got %q", params.VariantID, params.Source)
+				}
 			}
 		}
 	}
@@ -921,5 +966,88 @@ func TestMockOutboxStore_FindScaleJobForWindow(t *testing.T) {
 
 	if notFoundDifferentPool != nil {
 		t.Error("expected nil for different pool, got job")
+	}
+}
+
+func TestScaler_ScaleDown_PrefersPredictor(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+
+	// Add 3 free instances: 1 pool, 2 predictor
+	instanceStore.AddInstance(&types.Instance{
+		ID: "inst-pool-1", Pool: "pool-1", VariantID: "default",
+		Image: "ubuntu-2204", State: types.StateCreated, Source: types.InstanceSourcePool,
+	})
+	instanceStore.AddInstance(&types.Instance{
+		ID: "inst-pred-1", Pool: "pool-1", VariantID: "default",
+		Image: "ubuntu-2204", State: types.StateCreated, Source: types.InstanceSourcePredictor,
+	})
+	instanceStore.AddInstance(&types.Instance{
+		ID: "inst-pred-2", Pool: "pool-1", VariantID: "default",
+		Image: "ubuntu-2204", State: types.StateCreated, Source: types.InstanceSourcePredictor,
+	})
+
+	// Test that FindAndClaim with PreferSource picks predictor first
+	queryParams := &types.QueryParams{
+		PoolName:     "pool-1",
+		VariantID:    "default",
+		ImageName:    "ubuntu-2204",
+		PreferSource: types.InstanceSourcePredictor,
+	}
+
+	// First claim: should get a predictor instance
+	inst, err := instanceStore.FindAndClaim(
+		context.Background(), queryParams, types.StateTerminating,
+		[]types.InstanceState{types.StateCreated}, false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst == nil {
+		t.Fatal("expected instance, got nil")
+	}
+	if inst.Source != types.InstanceSourcePredictor {
+		t.Errorf("expected predictor instance first, got source=%q id=%s", inst.Source, inst.ID)
+	}
+
+	// Second claim: should get second predictor instance
+	inst2, err := instanceStore.FindAndClaim(
+		context.Background(), queryParams, types.StateTerminating,
+		[]types.InstanceState{types.StateCreated}, false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst2 == nil {
+		t.Fatal("expected second instance, got nil")
+	}
+	if inst2.Source != types.InstanceSourcePredictor {
+		t.Errorf("expected predictor instance second, got source=%q id=%s", inst2.Source, inst2.ID)
+	}
+
+	// Third claim: should get pool instance (only one left in StateCreated)
+	inst3, err := instanceStore.FindAndClaim(
+		context.Background(), queryParams, types.StateTerminating,
+		[]types.InstanceState{types.StateCreated}, false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst3 == nil {
+		t.Fatal("expected third instance, got nil")
+	}
+	if inst3.Source != types.InstanceSourcePool {
+		t.Errorf("expected pool instance third, got source=%q id=%s", inst3.Source, inst3.ID)
+	}
+
+	// Fourth claim: no more StateCreated instances
+	inst4, err := instanceStore.FindAndClaim(
+		context.Background(), queryParams, types.StateTerminating,
+		[]types.InstanceState{types.StateCreated}, false,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst4 != nil {
+		t.Errorf("expected nil (no more free instances), got id=%s", inst4.ID)
 	}
 }

--- a/app/scheduler/jobs/scaler_test.go
+++ b/app/scheduler/jobs/scaler_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -125,17 +126,18 @@ func (m *MockInstanceStore) FindAndClaim(
 			(params.ImageName == "" || inst.Image == params.ImageName)
 	}
 
-	// First pass: find instances matching preferred source
-	if params.PreferSource != "" {
+	// If FilterSource is set, only match instances with that source
+	if params.FilterSource != "" {
 		for i, inst := range m.instances {
-			if matches(inst) && inst.Source == params.PreferSource {
+			if matches(inst) && inst.Source == params.FilterSource {
 				m.instances[i].State = newState
 				return m.instances[i], nil
 			}
 		}
+		return nil, errors.New("no matching instance with source " + string(params.FilterSource))
 	}
 
-	// Second pass: any matching instance
+	// No source filter: any matching instance
 	for i, inst := range m.instances {
 		if matches(inst) {
 			m.instances[i].State = newState
@@ -969,7 +971,7 @@ func TestMockOutboxStore_FindScaleJobForWindow(t *testing.T) {
 	}
 }
 
-func TestScaler_ScaleDown_PrefersPredictor(t *testing.T) {
+func TestScaler_ScaleDown_FiltersPredictor(t *testing.T) {
 	instanceStore := NewMockInstanceStore()
 
 	// Add 3 free instances: 1 pool, 2 predictor
@@ -986,12 +988,12 @@ func TestScaler_ScaleDown_PrefersPredictor(t *testing.T) {
 		Image: "ubuntu-2204", State: types.StateCreated, Source: types.InstanceSourcePredictor,
 	})
 
-	// Test that FindAndClaim with PreferSource picks predictor first
+	// Test that FindAndClaim with FilterSource only returns predictor instances
 	queryParams := &types.QueryParams{
 		PoolName:     "pool-1",
 		VariantID:    "default",
 		ImageName:    "ubuntu-2204",
-		PreferSource: types.InstanceSourcePredictor,
+		FilterSource: types.InstanceSourcePredictor,
 	}
 
 	// First claim: should get a predictor instance
@@ -1024,30 +1026,12 @@ func TestScaler_ScaleDown_PrefersPredictor(t *testing.T) {
 		t.Errorf("expected predictor instance second, got source=%q id=%s", inst2.Source, inst2.ID)
 	}
 
-	// Third claim: should get pool instance (only one left in StateCreated)
-	inst3, err := instanceStore.FindAndClaim(
+	// Third claim: should fail — no more predictor instances (pool instances are NOT returned)
+	_, err = instanceStore.FindAndClaim(
 		context.Background(), queryParams, types.StateTerminating,
 		[]types.InstanceState{types.StateCreated}, false,
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if inst3 == nil {
-		t.Fatal("expected third instance, got nil")
-	}
-	if inst3.Source != types.InstanceSourcePool {
-		t.Errorf("expected pool instance third, got source=%q id=%s", inst3.Source, inst3.ID)
-	}
-
-	// Fourth claim: no more StateCreated instances
-	inst4, err := instanceStore.FindAndClaim(
-		context.Background(), queryParams, types.StateTerminating,
-		[]types.InstanceState{types.StateCreated}, false,
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if inst4 != nil {
-		t.Errorf("expected nil (no more free instances), got id=%s", inst4.ID)
+	if err == nil {
+		t.Error("expected error when no more predictor instances, got nil")
 	}
 }

--- a/metric/builds.go
+++ b/metric/builds.go
@@ -47,6 +47,7 @@ type label struct {
 	driver    string
 	ownerID   string
 	variantID string
+	source    string
 }
 
 type Store struct {
@@ -115,7 +116,7 @@ func RunningCount() *prometheus.GaugeVec {
 			Name: "harness_ci_pipeline_running_executions",
 			Help: "Total number of running executions",
 		},
-		[]string{"pool_id", "os", "arch", "driver", "state", "distributed", "owner_id", "variant_id"}, // state can be running, in_use, or hibernating
+		[]string{"pool_id", "os", "arch", "driver", "state", "distributed", "owner_id", "variant_id", "source"}, // state can be running, in_use, or hibernating
 	)
 }
 
@@ -193,14 +194,14 @@ func (m *Metrics) updateRunningCount(ctx context.Context, metricStore *Store, wg
 		return
 	}
 	for _, i := range instances {
-		l := label{os: i.OS, arch: i.Arch, state: string(i.State), poolID: i.Pool, driver: string(i.Provider), ownerID: i.OwnerID, variantID: i.VariantID}
+		l := label{os: i.OS, arch: i.Arch, state: string(i.State), poolID: i.Pool, driver: string(i.Provider), ownerID: i.OwnerID, variantID: i.VariantID, source: string(i.Source)}
 		if i.OwnerID != "" {
 			m.RunningPerAccountCount.WithLabelValues(i.OwnerID, i.OS, strconv.FormatBool(metricStore.Distributed)).Inc()
 		}
 		d[l]++
 	}
 	for k, v := range d {
-		m.RunningCount.WithLabelValues(k.poolID, k.os, k.arch, k.driver, k.state, strconv.FormatBool(metricStore.Distributed), k.ownerID, k.variantID).Set(float64(v))
+		m.RunningCount.WithLabelValues(k.poolID, k.os, k.arch, k.driver, k.state, strconv.FormatBool(metricStore.Distributed), k.ownerID, k.variantID, k.source).Set(float64(v))
 	}
 }
 

--- a/store/database/migrate/postgres/0021_update_table_instances_source.up.sql
+++ b/store/database/migrate/postgres/0021_update_table_instances_source.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS instance_source VARCHAR(20) DEFAULT 'unknown';

--- a/store/database/migrate/sqlite/0012_update_table_instances_source.up.sql
+++ b/store/database/migrate/sqlite/0012_update_table_instances_source.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instances ADD COLUMN instance_source VARCHAR(20) DEFAULT 'unknown';

--- a/store/database/sql/instances.go
+++ b/store/database/sql/instances.go
@@ -176,6 +176,12 @@ func (s InstanceStore) FindAndClaim(
 		subQuery = subQuery.Where(squirrel.Eq{"instance_state": stateVals})
 	}
 
+	if params.PreferSource != "" {
+		subQuery = subQuery.OrderByClause(
+			fmt.Sprintf("CASE WHEN instance_source = '%s' THEN 0 ELSE 1 END ASC", string(params.PreferSource)),
+		)
+	}
+
 	subQuery = subQuery.OrderBy("instance_started ASC").Limit(1).Suffix("FOR UPDATE SKIP LOCKED")
 
 	// --- Convert subquery to SQL + args ---
@@ -223,7 +229,7 @@ RETURNING %s
 		&dst.TLSCert, &dst.Started, &dst.Updated, &dst.IsHibernated,
 		&dst.Port, &dst.OwnerID, &dst.StorageIdentifier, &dst.Labels,
 		&dst.EnableNestedVirtualization, &dst.RunnerName, &dst.VariantID,
-		&dst.GPU,
+		&dst.GPU, &dst.Source,
 	)
 	if err != nil {
 		return nil, err
@@ -273,6 +279,7 @@ const instanceColumns = `
 ,runner_name
 ,variant_id
 ,instance_gpu
+,instance_source
 `
 
 const instanceFindByID = `SELECT ` + instanceColumns + `
@@ -314,6 +321,7 @@ INSERT INTO instances (
 ,enable_nested_virtualization
 ,variant_id
 ,instance_gpu
+,instance_source
 ) values (
  :instance_id
 ,:instance_node_id
@@ -347,6 +355,7 @@ INSERT INTO instances (
 ,:enable_nested_virtualization
 ,:variant_id
 ,:instance_gpu
+,:instance_source
 ) RETURNING instance_id
 `
 

--- a/store/database/sql/instances.go
+++ b/store/database/sql/instances.go
@@ -176,10 +176,8 @@ func (s InstanceStore) FindAndClaim(
 		subQuery = subQuery.Where(squirrel.Eq{"instance_state": stateVals})
 	}
 
-	if params.PreferSource != "" {
-		subQuery = subQuery.OrderByClause(
-			"CASE WHEN instance_source = ? THEN 0 ELSE 1 END ASC", string(params.PreferSource),
-		)
+	if params.FilterSource != "" {
+		subQuery = subQuery.Where(squirrel.Eq{"instance_source": string(params.FilterSource)})
 	}
 
 	subQuery = subQuery.OrderBy("instance_started ASC").Limit(1).Suffix("FOR UPDATE SKIP LOCKED")

--- a/store/database/sql/instances.go
+++ b/store/database/sql/instances.go
@@ -178,7 +178,7 @@ func (s InstanceStore) FindAndClaim(
 
 	if params.PreferSource != "" {
 		subQuery = subQuery.OrderByClause(
-			fmt.Sprintf("CASE WHEN instance_source = '%s' THEN 0 ELSE 1 END ASC", string(params.PreferSource)),
+			"CASE WHEN instance_source = ? THEN 0 ELSE 1 END ASC", string(params.PreferSource),
 		)
 	}
 

--- a/types/types.go
+++ b/types/types.go
@@ -220,7 +220,7 @@ type QueryParams struct {
 	NestedVirtualization bool
 	GPU                  bool
 	VariantID            string
-	PreferSource         InstanceSource
+	FilterSource         InstanceSource
 }
 
 type StageOwner struct {

--- a/types/types.go
+++ b/types/types.go
@@ -52,6 +52,16 @@ const (
 	StateProvisioning = InstanceState("provisioning") // VM created but not yet ready for use
 )
 
+// InstanceSource represents who created an instance.
+type InstanceSource string
+
+const (
+	InstanceSourceUnknown   InstanceSource = "unknown"
+	InstanceSourcePool      InstanceSource = "pool"
+	InstanceSourcePredictor InstanceSource = "predictor"
+	InstanceSourceOnDemand  InstanceSource = "ondemand"
+)
+
 // CapacityReservationState type enumeration.
 const (
 	CapacityReservationStateCreated     = CapacityReservationState("created")
@@ -94,9 +104,10 @@ type Instance struct {
 	GitspacePortMappings       map[int]int `json:"gitspaces_port_mappings"`
 	StorageIdentifier          string      `db:"instance_storage_identifier" json:"storage_identifier"`
 	Labels                     []byte      `db:"instance_labels" json:"instance_labels"`
-	EnableNestedVirtualization bool        `db:"enable_nested_virtualization" json:"enable_nested_virtualization"`
-	VariantID                  string      `db:"variant_id" json:"variant_id"`
-	GPU                        bool        `db:"instance_gpu" json:"gpu"`
+	EnableNestedVirtualization bool           `db:"enable_nested_virtualization" json:"enable_nested_virtualization"`
+	VariantID                  string         `db:"variant_id" json:"variant_id"`
+	GPU                        bool           `db:"instance_gpu" json:"gpu"`
+	Source                     InstanceSource `db:"instance_source" json:"source"`
 }
 
 // Passwords holds sensitive data.
@@ -209,6 +220,7 @@ type QueryParams struct {
 	NestedVirtualization bool
 	GPU                  bool
 	VariantID            string
+	PreferSource         InstanceSource
 }
 
 type StageOwner struct {
@@ -325,10 +337,11 @@ type SetupInstanceParams struct {
 	Hibernate            bool     `json:"hibernate,omitempty" yaml:"hibernate,omitempty"`
 	Zones                []string `json:"zones,omitempty" yaml:"zones,omitempty"`
 	VariantID            string   `json:"variant_id,omitempty" yaml:"variant_id,omitempty"`
-	DiskSize             int64    `json:"disk_size,omitempty" yaml:"disk_size,omitempty"`
-	DiskType             string   `json:"disk_type,omitempty" yaml:"disk_type,omitempty"`
-	ResourceClass        string   `json:"resource_class,omitempty" yaml:"resource_class,omitempty"`
-	GPU                  bool     `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	DiskSize             int64          `json:"disk_size,omitempty" yaml:"disk_size,omitempty"`
+	DiskType             string         `json:"disk_type,omitempty" yaml:"disk_type,omitempty"`
+	ResourceClass        string         `json:"resource_class,omitempty" yaml:"resource_class,omitempty"`
+	GPU                  bool           `json:"gpu,omitempty" yaml:"gpu,omitempty"`
+	Source               InstanceSource `json:"source,omitempty" yaml:"source,omitempty"`
 }
 
 // ScaleJobParams represents the parameters for a scaling job.

--- a/types/types.go
+++ b/types/types.go
@@ -91,19 +91,19 @@ type Instance struct {
 	Size                       string        `db:"instance_size" json:"size"`
 	OwnerID                    string        `db:"instance_owner_id" json:"owner_id"`
 	Platform                   `json:"platform"`
-	CAKey                      []byte      `db:"instance_ca_key" json:"ca_key"`
-	CACert                     []byte      `db:"instance_ca_cert" json:"ca_cert"`
-	TLSKey                     []byte      `db:"instance_tls_key" json:"tls_key"`
-	TLSCert                    []byte      `db:"instance_tls_cert" json:"tls_cert"`
-	Stage                      string      `db:"instance_stage" json:"stage"`
-	Updated                    int64       `db:"instance_updated" json:"updated"`
-	Started                    int64       `db:"instance_started" json:"started"`
-	IsHibernated               bool        `db:"is_hibernated" json:"is_hibernated"`
-	Port                       int64       `db:"instance_port" json:"port"`
-	RunnerName                 string      `db:"runner_name" json:"runner_name"`
-	GitspacePortMappings       map[int]int `json:"gitspaces_port_mappings"`
-	StorageIdentifier          string      `db:"instance_storage_identifier" json:"storage_identifier"`
-	Labels                     []byte      `db:"instance_labels" json:"instance_labels"`
+	CAKey                      []byte         `db:"instance_ca_key" json:"ca_key"`
+	CACert                     []byte         `db:"instance_ca_cert" json:"ca_cert"`
+	TLSKey                     []byte         `db:"instance_tls_key" json:"tls_key"`
+	TLSCert                    []byte         `db:"instance_tls_cert" json:"tls_cert"`
+	Stage                      string         `db:"instance_stage" json:"stage"`
+	Updated                    int64          `db:"instance_updated" json:"updated"`
+	Started                    int64          `db:"instance_started" json:"started"`
+	IsHibernated               bool           `db:"is_hibernated" json:"is_hibernated"`
+	Port                       int64          `db:"instance_port" json:"port"`
+	RunnerName                 string         `db:"runner_name" json:"runner_name"`
+	GitspacePortMappings       map[int]int    `json:"gitspaces_port_mappings"`
+	StorageIdentifier          string         `db:"instance_storage_identifier" json:"storage_identifier"`
+	Labels                     []byte         `db:"instance_labels" json:"instance_labels"`
 	EnableNestedVirtualization bool           `db:"enable_nested_virtualization" json:"enable_nested_virtualization"`
 	VariantID                  string         `db:"variant_id" json:"variant_id"`
 	GPU                        bool           `db:"instance_gpu" json:"gpu"`
@@ -331,12 +331,12 @@ type OutboxJob struct {
 
 // SetupInstanceParams represents the additional parameters for setting up an instance asynchronously
 type SetupInstanceParams struct {
-	ImageName            string   `json:"image_name,omitempty" yaml:"image_name,omitempty"`
-	NestedVirtualization bool     `json:"enable_nested_virtualization,omitempty" yaml:"enable_nested_virtualization,omitempty"`
-	MachineType          string   `json:"machine_type,omitempty" yaml:"machine_type,omitempty"`
-	Hibernate            bool     `json:"hibernate,omitempty" yaml:"hibernate,omitempty"`
-	Zones                []string `json:"zones,omitempty" yaml:"zones,omitempty"`
-	VariantID            string   `json:"variant_id,omitempty" yaml:"variant_id,omitempty"`
+	ImageName            string         `json:"image_name,omitempty" yaml:"image_name,omitempty"`
+	NestedVirtualization bool           `json:"enable_nested_virtualization,omitempty" yaml:"enable_nested_virtualization,omitempty"`
+	MachineType          string         `json:"machine_type,omitempty" yaml:"machine_type,omitempty"`
+	Hibernate            bool           `json:"hibernate,omitempty" yaml:"hibernate,omitempty"`
+	Zones                []string       `json:"zones,omitempty" yaml:"zones,omitempty"`
+	VariantID            string         `json:"variant_id,omitempty" yaml:"variant_id,omitempty"`
 	DiskSize             int64          `json:"disk_size,omitempty" yaml:"disk_size,omitempty"`
 	DiskType             string         `json:"disk_type,omitempty" yaml:"disk_type,omitempty"`
 	ResourceClass        string         `json:"resource_class,omitempty" yaml:"resource_class,omitempty"`

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestInstanceSourceConstants(t *testing.T) {
+	tests := []struct {
+		source InstanceSource
+		want   string
+	}{
+		{InstanceSourceUnknown, "unknown"},
+		{InstanceSourcePool, "pool"},
+		{InstanceSourcePredictor, "predictor"},
+		{InstanceSourceOnDemand, "ondemand"},
+	}
+	for _, tt := range tests {
+		if string(tt.source) != tt.want {
+			t.Errorf("expected %q, got %q", tt.want, string(tt.source))
+		}
+	}
+}
+
+func TestSetupInstanceParams_SourceJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		source InstanceSource
+	}{
+		{"pool", InstanceSourcePool},
+		{"predictor", InstanceSourcePredictor},
+		{"ondemand", InstanceSourceOnDemand},
+		{"unknown", InstanceSourceUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := SetupInstanceParams{
+				VariantID: "variant-1",
+				ImageName: "ubuntu-2204",
+				Source:    tt.source,
+			}
+
+			data, err := json.Marshal(params)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			var decoded SetupInstanceParams
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if decoded.Source != tt.source {
+				t.Errorf("Source: expected %q, got %q", tt.source, decoded.Source)
+			}
+			if decoded.VariantID != "variant-1" {
+				t.Errorf("VariantID: expected %q, got %q", "variant-1", decoded.VariantID)
+			}
+		})
+	}
+}
+
+func TestSetupInstanceParams_EmptySourceOmittedInJSON(t *testing.T) {
+	params := SetupInstanceParams{VariantID: "v1"}
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Source has omitempty, so empty source should not appear in JSON
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+	if _, exists := raw["source"]; exists {
+		t.Error("expected empty source to be omitted from JSON, but it was present")
+	}
+}


### PR DESCRIPTION
## Problem
Predictor-created VMs cause ~2x over-provisioning. When a hotpool VM is claimed, the replenishment mechanism always creates a replacement, regardless of who created the original instance. This means predictor VMs (pre-scaled for upcoming demand) get replaced on claim, doubling the effective count.

## Root Cause
`setupInstanceAsync` in `distributed_manager.go` unconditionally creates a replacement for every claimed instance. There was no way to distinguish between pool-maintained instances (which should be replenished to maintain the static floor) and predictor/on-demand instances (which should not).

## Solution
Tag each instance with its creation source and gate replenishment on source type:
- **pool** — static pool instances, always replenished
- **predictor** — scaler-created instances, NOT replenished (scaler manages lifecycle)
- **ondemand** — on-demand fallback instances, NOT replenished
- **unknown** — legacy/existing instances (DB default), NOT replenished (drain naturally)

Scale-down prefers destroying predictor instances first via `PreferSource` ordering in `FindAndClaim`, preserving the static pool floor.

## Changes Made
| File | Change |
|------|--------|
| `types/types.go` | `InstanceSource` type, 4 constants, `Source` field on `Instance`/`SetupInstanceParams`, `PreferSource` on `QueryParams` |
| `store/database/migrate/postgres/0021_*` | Add `instance_source` column (DEFAULT 'unknown') |
| `store/database/migrate/sqlite/0012_*` | Same for SQLite |
| `store/database/sql/instances.go` | Column in insert/scan, `PreferSource` ORDER BY in `FindAndClaim` |
| `app/drivers/provisioner.go` | `resolveInstanceSource()` helper, defaults to `pool` |
| `app/drivers/distributed_manager.go` | `shouldReplenishInstance()` gates replenishment, on-demand source tagging |
| `app/scheduler/jobs/scaler.go` | `Source: predictor` on scale-up, `PreferSource: predictor` on scale-down |
| `metric/builds.go` | `source` label added to `RunningCount` metric |

## Testing
- `TestShouldReplenishInstance` — 5 cases (pool=true, predictor/ondemand/empty/unknown=false)
- `TestResolveInstanceSource` — all source types + nil/empty edge cases
- `TestScaler_ScaleUp` / `TestScaler_WithVariants` — verify source=predictor on created instances
- `TestScaler_ScaleDown_PrefersPredictor` — predictor instances claimed first
- `TestSetupInstanceParams_SourceJSONRoundTrip` — JSON serialization round-trip
- `TestSetupInstanceParams_EmptySourceOmittedInJSON` — omitempty behavior
- All 17 test packages pass (verified by pre-push hook)

## Related Issues/Logs
- [CI-22008](https://harness.atlassian.net/browse/CI-22008)
- Related: CI-21886 (predictor tuning for over-provisioning)

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-22008]: https://harness.atlassian.net/browse/CI-22008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ