### PR TITLE
fix: [CI-22070]: update harness-vm-runner to consume updated lite engine

### DIFF
--- a/config/binary-versions.yaml
+++ b/config/binary-versions.yaml
@@ -20,7 +20,7 @@ registry: "gar"
 
 binaries:
   lite-engine:
-    version: "1.2.0"
+    version: "1.4.0"
     image: "harness-vm-runner-lite-engine"
     description: "Harness CI execution engine"
 

--- a/docker/Dockerfile-harness-vm-runner
+++ b/docker/Dockerfile-harness-vm-runner
@@ -31,7 +31,7 @@ ARG GIT_TAG
 
 # Binary versions for runtime dependencies
 # Lite-engine must match go.mod dependency
-ARG LITE_ENGINE_VERSION=1.2.0
+ARG LITE_ENGINE_VERSION=1.4.0
 ARG PLUGIN_VERSION=1.5.0
 ARG AUTO_INJECTION_VERSION=1.1.0
 ARG HCLI_VERSION=1.3.0

--- a/docker/Dockerfile-harness-vm-runner-binaries
+++ b/docker/Dockerfile-harness-vm-runner-binaries
@@ -11,7 +11,7 @@
 # creating VMs and binaries are extracted and injected via cloud-init.
 
 # Binary versions - must match binary-versions.yaml
-ARG LITE_ENGINE_VERSION=1.2.0
+ARG LITE_ENGINE_VERSION=1.4.0
 ARG PLUGIN_VERSION=1.5.0
 ARG AUTO_INJECTION_VERSION=1.1.0
 ARG HCLI_VERSION=1.3.0


### PR DESCRIPTION
lite-engine 1.2.0 → 1.4.0 across config/binary-versions.yaml, Dockerfile-harness-vm-runner, and Dockerfile-harness-vm-runner-binaries   