### PR TITLE
fix: [CI-22072]: add InstanceRunningWaiter for hibernate resume and fix Windows health check timeout

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -939,7 +939,15 @@ func (p *amazonConfig) Start(ctx context.Context, instance *drtypes.Instance, po
 	state := p.getState(amazonInstance)
 	if state == string(types.InstanceStateNameRunning) {
 		return p.getIP(amazonInstance), nil
-	} else if state == string(types.InstanceStateNameStopping) {
+	}
+
+	// Instance is in a terminal state and cannot be started
+	if state == string(types.InstanceStateNameTerminated) || state == string(types.InstanceStateNameShuttingDown) {
+		logr.WithField("state", state).Errorln("aws: instance is in a terminal state, cannot start")
+		return "", fmt.Errorf("instance %s is in terminal state %q and cannot be started", instance.ID, state)
+	}
+
+	if state == string(types.InstanceStateNameStopping) {
 		logr.Traceln("aws: waiting for instance to stop")
 		waiter := ec2.NewInstanceStoppedWaiter(client)
 		waitErr := waiter.Wait(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instance.ID}}, instanceWaitTimeout)
@@ -955,7 +963,25 @@ func (p *amazonConfig) Start(ctx context.Context, instance *drtypes.Instance, po
 			Errorln("aws: failed to start VMs")
 		return "", err
 	}
-	logr.Traceln("amazon: VM started")
+	logr.Traceln("amazon: StartInstances API call successful, waiting for instance to reach running state")
+
+	// Wait for instance to reach running state before polling for IP.
+	// This is critical for Windows instances resuming from hibernation, which can
+	// take significantly longer to boot. Without this wait, we would immediately
+	// start polling for an IP on an instance that may still be in 'pending' or
+	// stuck in 'stopped' state, wasting time on fruitless polling.
+	waiter := ec2.NewInstanceRunningWaiter(client)
+	waitErr := waiter.Wait(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instance.ID}}, instanceWaitTimeout)
+	if waitErr != nil {
+		logr.WithError(waitErr).Errorln("aws: instance failed to reach running state after start")
+		// Check if instance is in a terminal state
+		if postStartInstance, getErr := p.getInstance(ctx, instance.ID); getErr == nil {
+			postState := p.getState(postStartInstance)
+			logr.WithField("state", postState).Errorln("aws: instance state after failed start wait")
+		}
+		return "", fmt.Errorf("instance %s failed to reach running state: %w", instance.ID, waitErr)
+	}
+	logr.Traceln("amazon: instance is now running")
 
 	awsInstance, err := p.pollInstanceIPAddr(ctx, instance.ID, logr)
 	if err != nil {
@@ -1128,6 +1154,24 @@ func (p *amazonConfig) pollInstanceIPAddr(ctx context.Context, instanceID string
 			}
 
 			instance := desc.Reservations[0].Instances[0]
+
+			// Fail fast if the instance is in a terminal or stopped state - it will never get an IP
+			if instance.State != nil {
+				stateName := instance.State.Name
+				if stateName == types.InstanceStateNameTerminated ||
+					stateName == types.InstanceStateNameShuttingDown {
+					logr.WithField("state", stateName).
+						Errorln("amazon: [provision] instance is in terminal state, will never get an IP")
+					return nil, fmt.Errorf("instance %s is in terminal state %q", instanceID, stateName)
+				}
+				if stateName == types.InstanceStateNameStopped ||
+					stateName == types.InstanceStateNameStopping {
+					logr.WithField("state", stateName).
+						Warnln("amazon: [provision] instance is stopped/stopping, cannot get an IP")
+					return nil, fmt.Errorf("instance %s is in state %q, expected running", instanceID, stateName)
+				}
+			}
+
 			instanceIP := p.getIP(&instance)
 
 			if instanceIP == "" {

--- a/app/drivers/amazon/driver_test.go
+++ b/app/drivers/amazon/driver_test.go
@@ -779,3 +779,144 @@ func TestGetDynamicConfig_RoundRobinSetsSubnet(t *testing.T) {
 	assert.Equal(t, "us-east-1b", cfg2.availabilityZone)
 	assert.Equal(t, "subnet-bbb", cfg2.subnet)
 }
+
+// TestStart tests the Start method for hibernate resume behavior
+func TestStart(t *testing.T) {
+	instanceID := "i-1234567890abcdef0"
+
+	tests := []struct {
+		name    string
+		mock    *mockEC2Client
+		wantErr bool
+		wantIP  string
+		errMsg  string
+	}{
+		{
+			name: "instance already running",
+			mock: &mockEC2Client{
+				DescribeInstancesFunc: func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []types.Reservation{
+							{
+								Instances: []types.Instance{
+									{
+										InstanceId:       aws.String(instanceID),
+										PrivateIpAddress: aws.String("10.0.0.1"),
+										State: &types.InstanceState{
+											Name: types.InstanceStateNameRunning,
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			wantErr: false,
+			wantIP:  "10.0.0.1",
+		},
+		{
+			name: "instance terminated - cannot start",
+			mock: &mockEC2Client{
+				DescribeInstancesFunc: func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []types.Reservation{
+							{
+								Instances: []types.Instance{
+									{
+										InstanceId: aws.String(instanceID),
+										State: &types.InstanceState{
+											Name: types.InstanceStateNameTerminated,
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			wantErr: true,
+			errMsg:  "terminal state",
+		},
+		{
+			name: "instance shutting-down - cannot start",
+			mock: &mockEC2Client{
+				DescribeInstancesFunc: func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []types.Reservation{
+							{
+								Instances: []types.Instance{
+									{
+										InstanceId: aws.String(instanceID),
+										State: &types.InstanceState{
+											Name: types.InstanceStateNameShuttingDown,
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			wantErr: true,
+			errMsg:  "terminal state",
+		},
+		{
+			name: "StartInstances API fails",
+			mock: &mockEC2Client{
+				DescribeInstancesFunc: func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+					return &ec2.DescribeInstancesOutput{
+						Reservations: []types.Reservation{
+							{
+								Instances: []types.Instance{
+									{
+										InstanceId: aws.String(instanceID),
+										State: &types.InstanceState{
+											Name: types.InstanceStateNameStopped,
+										},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+				StartInstancesFunc: func(ctx context.Context, params *ec2.StartInstancesInput, optFns ...func(*ec2.Options)) (*ec2.StartInstancesOutput, error) {
+					return nil, errors.New("insufficient capacity")
+				},
+			},
+			wantErr: true,
+			errMsg:  "insufficient capacity",
+		},
+		{
+			name: "getInstance fails",
+			mock: &mockEC2Client{
+				DescribeInstancesFunc: func(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+					return nil, errors.New("describe failed")
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to get instance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &amazonConfig{
+				service: tt.mock,
+			}
+			instance := &drtypes.Instance{
+				ID: instanceID,
+			}
+			ip, err := p.Start(context.Background(), instance, "test-pool")
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantIP, ip)
+			}
+		})
+	}
+}

--- a/app/drivers/health.go
+++ b/app/drivers/health.go
@@ -37,9 +37,16 @@ func (m *Manager) GetRunnerConfig() types.RunnerConfig {
 
 // GetHealthCheckTimeout returns the appropriate health check timeout based on the OS, provider, warmed status, and hibernated status.
 func (m *Manager) GetHealthCheckTimeout(os string, provider types.DriverType, warmed, hibernated bool) time.Duration {
-	// Override for Windows
+	// For Windows instances resuming from hibernation, use the larger of the
+	// Windows and hibernated timeouts. Windows hibernate resume involves both
+	// OS-level boot delays and hibernate disk restore, so it needs the maximum
+	// of both timeout values.
 	if os == "windows" {
-		return m.runnerConfig.HealthCheckWindowsTimeout
+		windowsTimeout := m.runnerConfig.HealthCheckWindowsTimeout
+		if hibernated && m.runnerConfig.HealthCheckHibernatedTimeout > windowsTimeout {
+			return m.runnerConfig.HealthCheckHibernatedTimeout
+		}
+		return windowsTimeout
 	}
 
 	// Use hotpool timeout for Nomad (true hot pool with running processes)

--- a/app/drivers/manager_extended_test.go
+++ b/app/drivers/manager_extended_test.go
@@ -1661,6 +1661,106 @@ func TestManager_getStrategy(t *testing.T) {
 	}
 }
 
+// TestGetHealthCheckTimeout_WindowsHibernated tests that Windows + hibernated
+// instances use the larger of HealthCheckWindowsTimeout and HealthCheckHibernatedTimeout
+func TestGetHealthCheckTimeout_WindowsHibernated(t *testing.T) {
+	tests := []struct {
+		name               string
+		os                 string
+		provider           types.DriverType
+		warmed             bool
+		hibernated         bool
+		windowsTimeout     time.Duration
+		hibernatedTimeout  time.Duration
+		hotpoolTimeout     time.Duration
+		coldstartTimeout   time.Duration
+		expectedTimeout    time.Duration
+	}{
+		{
+			name:              "windows not hibernated - uses windows timeout",
+			os:                "windows",
+			provider:          types.Amazon,
+			warmed:            false,
+			hibernated:        false,
+			windowsTimeout:    5 * time.Minute,
+			hibernatedTimeout: 2 * time.Minute,
+			expectedTimeout:   5 * time.Minute,
+		},
+		{
+			name:              "windows hibernated - hibernated timeout larger",
+			os:                "windows",
+			provider:          types.Amazon,
+			warmed:            false,
+			hibernated:        true,
+			windowsTimeout:    5 * time.Minute,
+			hibernatedTimeout: 8 * time.Minute,
+			expectedTimeout:   8 * time.Minute,
+		},
+		{
+			name:              "windows hibernated - windows timeout larger",
+			os:                "windows",
+			provider:          types.Amazon,
+			warmed:            false,
+			hibernated:        true,
+			windowsTimeout:    10 * time.Minute,
+			hibernatedTimeout: 2 * time.Minute,
+			expectedTimeout:   10 * time.Minute,
+		},
+		{
+			name:              "linux hibernated - uses hibernated timeout",
+			os:                "linux",
+			provider:          types.Amazon,
+			warmed:            false,
+			hibernated:        true,
+			hibernatedTimeout: 2 * time.Minute,
+			coldstartTimeout:  3 * time.Minute,
+			expectedTimeout:   2 * time.Minute,
+		},
+		{
+			name:             "linux cold start - uses coldstart timeout",
+			os:               "linux",
+			provider:         types.Amazon,
+			warmed:           false,
+			hibernated:       false,
+			coldstartTimeout: 3 * time.Minute,
+			expectedTimeout:  3 * time.Minute,
+		},
+		{
+			name:           "linux warmed - uses hotpool timeout",
+			os:             "linux",
+			provider:       types.Amazon,
+			warmed:         true,
+			hibernated:     false,
+			hotpoolTimeout: 10 * time.Second,
+			expectedTimeout: 10 * time.Second,
+		},
+		{
+			name:           "nomad - uses hotpool timeout",
+			os:             "linux",
+			provider:       types.Nomad,
+			warmed:         false,
+			hibernated:     false,
+			hotpoolTimeout: 10 * time.Second,
+			expectedTimeout: 10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{
+				runnerConfig: types.RunnerConfig{
+					HealthCheckWindowsTimeout:    tt.windowsTimeout,
+					HealthCheckHibernatedTimeout: tt.hibernatedTimeout,
+					HealthCheckHotpoolTimeout:    tt.hotpoolTimeout,
+					HealthCheckColdstartTimeout:  tt.coldstartTimeout,
+				},
+			}
+			got := m.GetHealthCheckTimeout(tt.os, tt.provider, tt.warmed, tt.hibernated)
+			assert.Equal(t, tt.expectedTimeout, got, "timeout mismatch for %s", tt.name)
+		})
+	}
+}
+
 // Mock strategy for testing
 type mockStrategy struct{}
 


### PR DESCRIPTION
## Problem

Customer experiences intermittent failures every 3-4 months where AWS Windows EC2 instances fail to resume from hibernation. The delegate cannot connect to lite-engine, instances stay in stopped state, and the runner DB gets out of sync with actual AWS state.

Recurring issue tracked across: CI-22072, CI-17310, CI-19489, CI-13607, CI-15890

## Root Cause

In `Start()` (`driver.go`), after calling `StartInstances()`, the code immediately called `pollInstanceIPAddr()` without waiting for the instance to reach `running` state. For Windows instances that fail to resume from hibernate:

1. **No running state verification**: `StartInstances()` is an async AWS API - it returns immediately. The instance may stay `stopped` if hibernate resume fails (e.g., disk corruption, Windows boot issue).
2. **Blind IP polling**: `pollInstanceIPAddr()` only checked for IP assignment, never checked instance state. It would poll for ~15 minutes on an instance stuck in `stopped` state.
3. **No terminal state handling**: If the instance was `terminated` or `shutting-down`, the code still attempted to start it.
4. **Windows health check timeout**: The timeout selection for Windows instances didn't consider the hibernated flag, so a Windows instance resuming from hibernate got the standard Windows timeout instead of the larger hibernated timeout.

## Solution

### Changes Made

**`app/drivers/amazon/driver.go`**:
- Added `ec2.NewInstanceRunningWaiter` after `StartInstances()` to explicitly wait for the instance to reach `running` state (5 min timeout) before polling for IP
- Added handling for terminal states (`terminated`, `shutting-down`) in `Start()` to fail fast with clear error
- Added state checking in `pollInstanceIPAddr()` to detect instances stuck in `stopped`/`terminated` state during IP polling, instead of blindly waiting for an IP that will never come

**`app/drivers/health.go`**:
- Fixed `GetHealthCheckTimeout` to use `max(windowsTimeout, hibernatedTimeout)` for Windows instances resuming from hibernation, ensuring they get adequate boot time

## Testing

- 5 new unit tests for `Start()` covering: already running, terminated, shutting-down, StartInstances failure, getInstance failure
- 7 new unit tests for `GetHealthCheckTimeout()` covering: windows not hibernated, windows+hibernated (both timeout orderings), linux hibernated, linux cold, linux warmed, nomad
- All existing tests pass

## Related Issues/Logs

- [CI-22072](https://harness.atlassian.net/browse/CI-22072) - Current ticket (2026)
- [CI-17310](https://harness.atlassian.net/browse/CI-17310) - Same issue (2025-04)
- [CI-19489](https://harness.atlassian.net/browse/CI-19489) - Same issue (2025-10)
- [CI-13607](https://harness.atlassian.net/browse/CI-13607) - Original report
- [CI-15890](https://harness.atlassian.net/browse/CI-15890) - Earlier recurrence

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-22072]: https://harness.atlassian.net/browse/CI-22072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ