### PR TITLE
feat: [CI-22066]: move IsHosted from context to manager config

### DIFF
--- a/app/drivers/health.go
+++ b/app/drivers/health.go
@@ -80,3 +80,8 @@ func (m *Manager) GetStartStepTimeout() time.Duration {
 func (m *Manager) IsDistributed() bool {
 	return false
 }
+
+// IsHosted returns whether the runner is operating in hosted mode.
+func (m *Manager) IsHosted() bool {
+	return m.hosted
+}

--- a/app/drivers/hibernator.go
+++ b/app/drivers/hibernator.go
@@ -221,7 +221,7 @@ func (m *Manager) waitForInstanceConnectivity(ctx context.Context, tlsServerName
 	}
 
 	_, err = client.RetryHealth(ctx, &api.HealthRequest{
-		PerformDNSLookup:                ShouldPerformDNSLookup(ctx, instance.Platform.OS, false),
+		PerformDNSLookup:                ShouldPerformDNSLookup(m.hosted, instance.Platform.OS, false),
 		Timeout:                         defaultConnectivityTimeout,
 		HealthCheckConnectivityDuration: m.GetHealthCheckConnectivityDuration(),
 	})

--- a/app/drivers/interfaces.go
+++ b/app/drivers/interfaces.go
@@ -120,6 +120,9 @@ type ConfigProvider interface {
 	// IsDistributed returns whether the manager is in distributed mode.
 	IsDistributed() bool
 
+	// IsHosted returns whether the runner is operating in hosted mode.
+	IsHosted() bool
+
 	// GetRunnerConfig returns the runner configuration.
 	GetRunnerConfig() types.RunnerConfig
 

--- a/app/drivers/manager.go
+++ b/app/drivers/manager.go
@@ -43,6 +43,7 @@ type (
 		tmateBinaryFallbackURI       string
 		env                          string
 		skipCloudInitPackages        bool
+		hosted                       bool
 	}
 
 	poolEntry struct {

--- a/app/drivers/manager_config.go
+++ b/app/drivers/manager_config.go
@@ -41,6 +41,7 @@ type ManagerConfig struct {
 	TmateBinaryURI               string
 	TmateBinaryFallbackURI       string
 	SkipCloudInitPackages        bool
+	Hosted                       bool
 }
 
 // NewManagerFromConfig creates a new Manager from a ManagerConfig.
@@ -68,6 +69,7 @@ func NewManagerFromConfig(cfg *ManagerConfig) *Manager {
 		tmateBinaryURI:               cfg.TmateBinaryURI,
 		tmateBinaryFallbackURI:       cfg.TmateBinaryFallbackURI,
 		skipCloudInitPackages:        cfg.SkipCloudInitPackages,
+		hosted:                       cfg.Hosted,
 	}
 }
 

--- a/app/drivers/provisioner.go
+++ b/app/drivers/provisioner.go
@@ -197,7 +197,7 @@ func (m *Manager) setupInstance(
 
 	// generate certs
 	createOptions, err := certs.Generate(m.runnerName, tlsServerName)
-	createOptions.IsHosted = IsHosted(ctx)
+	createOptions.IsHosted = m.hosted
 	createOptions.LiteEnginePath = m.liteEnginePath
 	createOptions.LiteEngineFallbackPath = m.liteEngineFallbackPath
 	createOptions.PoolName = pool.Name

--- a/app/drivers/util.go
+++ b/app/drivers/util.go
@@ -1,12 +1,9 @@
 package drivers
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"strings"
-
-	"github.com/drone-runners/drone-runner-aws/types"
 )
 
 // callerPathDepth is the number of path components to keep when shortening file paths.
@@ -33,16 +30,8 @@ func getCallerInfo(skip int) string {
 	return fmt.Sprintf("%s:%d", short, line)
 }
 
-func IsHosted(ctx context.Context) bool {
-	isHosted := ctx.Value(types.Hosted)
-	if isHosted == nil {
-		return false
-	}
-	return isHosted.(bool)
-}
-
-func ShouldPerformDNSLookup(ctx context.Context, os string, warmedUp bool) bool {
-	if IsHosted(ctx) && (warmedUp || strings.EqualFold(os, "windows")) {
+func ShouldPerformDNSLookup(hosted bool, os string, warmedUp bool) bool {
+	if hosted && (warmedUp || strings.EqualFold(os, "windows")) {
 		return true
 	}
 	return false

--- a/command/harness/distributed.go
+++ b/command/harness/distributed.go
@@ -34,6 +34,7 @@ type DistributedSetupConfig struct {
 	Env      *config.EnvConfig
 	PoolFile string
 	Metrics  *metric.Metrics
+	Hosted   bool
 }
 
 // SetupDistributedMode initializes the distributed pool manager, scheduler, and all related components.
@@ -58,6 +59,7 @@ func SetupDistributedMode(cfg DistributedSetupConfig) (*DistributedSetupResult, 
 	managerCfg.StageOwnerStore = stageOwnerStore
 	managerCfg.CapacityReservationStore = capacityReservationStore
 	managerCfg.FirewallStore = firewallStore
+	managerCfg.Hosted = cfg.Hosted
 	poolManager := drivers.NewDistributedManager(
 		drivers.NewManagerFromConfig(&managerCfg),
 		outboxStore,

--- a/command/harness/dlite/dlite.go
+++ b/command/harness/dlite/dlite.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/drone-runners/drone-runner-aws/command/harness"
-	"github.com/drone-runners/drone-runner-aws/types"
 )
 
 // dliteCommand represents the dlite command configuration.
@@ -57,8 +56,7 @@ func (c *dliteCommand) run(*kingpin.ParseContext) error {
 		return err
 	}
 
-	// Set hosted context value.
-	ctx := context.WithValue(c.runner.Context(), types.Hosted, true)
+	ctx := c.runner.Context()
 
 	// Setup distributed pools (dlite always uses distributed mode).
 	if err := c.setupDistributedPool(ctx); err != nil {
@@ -96,6 +94,7 @@ func (c *dliteCommand) setupDistributedPool(ctx context.Context) error {
 			Env:      c.runner.Config,
 			PoolFile: c.poolFile,
 			Metrics:  c.runner.Metrics,
+			Hosted:   true,
 		},
 	)
 	if err != nil {

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -554,7 +554,7 @@ func handleSetup(
 	}
 	// try the healthcheck api on the lite-engine until it responds ok
 	ilog.Traceln("running healthcheck and waiting for an ok response")
-	performDNSLookup := drivers.ShouldPerformDNSLookup(ctx, instance.Platform.OS, warmed)
+	performDNSLookup := drivers.ShouldPerformDNSLookup(poolManager.IsHosted(), instance.Platform.OS, warmed)
 
 	// Get the health check timeout based on the instance OS, provider, warmed status, and hibernated status
 	healthCheckTimeout := poolManager.GetHealthCheckTimeout(instance.Platform.OS, instance.Provider, warmed, hibernated)

--- a/command/setup/setup.go
+++ b/command/setup/setup.go
@@ -199,7 +199,7 @@ func (c *setupCommand) run(*kingpin.ParseContext) error { //nolint
 
 	// try the healthcheck api on the lite-engine until it responds ok
 	logrus.Traceln("setup: running healthcheck and waiting for an ok response")
-	performDNSLookup := drivers.ShouldPerformDNSLookup(ctx, instance.Platform.OS, false)
+	performDNSLookup := drivers.ShouldPerformDNSLookup(poolManager.IsHosted(), instance.Platform.OS, false)
 
 	healthResponse, healthErr := leClient.RetryHealth(ctx, &api.HealthRequest{
 		PerformDNSLookup: performDNSLookup,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -109,7 +109,7 @@ func (e *Engine) Setup(ctx context.Context, specv runtime.Spec) error {
 
 	// try the healthcheck api on the lite-engine until it responds ok
 	logr.Traceln("running healthcheck and waiting for an ok response")
-	performDNSLookup := drivers.ShouldPerformDNSLookup(ctx, instance.Platform.OS, false)
+	performDNSLookup := drivers.ShouldPerformDNSLookup(e.poolManager.IsHosted(), instance.Platform.OS, false)
 
 	healthResponse, err := client.RetryHealth(ctx, &leapi.HealthRequest{
 		PerformDNSLookup: performDNSLookup,


### PR DESCRIPTION
## Problem

`IsHosted` relied on a context value (`types.Hosted`) that was set only in the dlite command entrypoint via `context.WithValue`. This approach is fragile — context values can be dropped across goroutine boundaries or when a new context is derived without carrying forward the original, causing `IsHosted` to silently return `false`.

## Root Cause

The hosted flag was propagated as a context key rather than as explicit manager configuration, making it unreliable for anything that runs outside the original context chain.

## Solution

Move the `hosted` flag into the manager config so it is always available as a first-class field on the `Manager` struct regardless of context.

## Changes Made

- **`app/drivers/manager.go`** — added `hosted bool` field to `Manager` struct
- **`app/drivers/manager_config.go`** — added `Hosted bool` to `ManagerConfig`; wired it through `NewManagerFromConfig`
- **`app/drivers/health.go`** — implemented `IsHosted() bool` on `Manager`
- **`app/drivers/interfaces.go`** — added `IsHosted() bool` to `ConfigProvider` interface
- **`app/drivers/util.go`** — removed context-based `IsHosted(ctx)`; changed `ShouldPerformDNSLookup` signature to `(hosted bool, os string, warmedUp bool)`
- **`app/drivers/provisioner.go`** — use `m.hosted` directly instead of `IsHosted(ctx)`
- **`app/drivers/hibernator.go`** — pass `m.hosted` to `ShouldPerformDNSLookup`
- **`command/harness/distributed.go`** — added `Hosted bool` to `DistributedSetupConfig`; forwarded to `managerCfg`
- **`command/harness/dlite/dlite.go`** — set `Hosted: true` in `DistributedSetupConfig`; removed `context.WithValue` and `types` import
- **`command/harness/setup.go`** — call `poolManager.IsHosted()` instead of reading from context
- **`command/setup/setup.go`** — call `poolManager.IsHosted()` instead of reading from context
- **`engine/engine.go`** — call `e.poolManager.IsHosted()` instead of reading from context

## Testing

- `go build ./...` — clean
- `go test ./...` — all tests pass

## Related Issues/Logs

Ticket: [CI-22066](https://harness.atlassian.net/browse/CI-22066)

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

Made with [Cursor](https://cursor.com)

[CI-22066]: https://harness.atlassian.net/browse/CI-22066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ