### PR TITLE
feat: [CI-22129]: move ScalePercent from predictor to scaler; hibernate buffer VMs

### DIFF
--- a/app/predictor/ema_weekend_decay_predictor.go
+++ b/app/predictor/ema_weekend_decay_predictor.go
@@ -34,11 +34,6 @@ type PredictorConfig struct { //nolint:revive
 	// Default: [0.85, 0.10, 0.05]
 	WeekDecayFactors [3]float64
 
-	// ScalePercent is the percentage of predicted VMs to target (e.g., 115 = 115% of predicted, 80 = 80%).
-	// Values above 100 over-provision, values below 100 under-provision.
-	// Default: 100 (no adjustment)
-	ScalePercent float64
-
 	// MinInstances is the minimum number of instances to recommend.
 	// Default: 0
 	MinInstances int
@@ -58,7 +53,6 @@ func DefaultPredictorConfig() PredictorConfig {
 		EMAPeriod:        3,
 		EMAWeight:        0.85,
 		WeekDecayFactors: [3]float64{0.85, 0.10, 0.05},
-		ScalePercent:     100,
 		MinInstances:     0,
 		MaxLookbackDays:  4,
 		TargetWeekdays:   2,
@@ -110,17 +104,15 @@ func (p *EMAWeekendDecayPredictor) Predict(ctx context.Context, input *Predictio
 		baseValue = p.combineValues(emaValue, historicalValue)
 	}
 
-	// Step 2: Apply scale percent adjustment
-	finalValue := baseValue * (p.config.ScalePercent / 100.0)
-
-	// Step 3: Round up and ensure minimum
-	recommendedInstances := int(math.Ceil(finalValue))
-	if recommendedInstances < p.config.MinInstances {
-		recommendedInstances = p.config.MinInstances
+	// Compute the predicted instance count and apply MinInstances floor.
+	// The scaler applies any over-provisioning buffer (ScalePercent).
+	predictedInstances := int(math.Ceil(baseValue))
+	if predictedInstances < p.config.MinInstances {
+		predictedInstances = p.config.MinInstances
 	}
 
 	return &PredictionResult{
-		RecommendedInstances: recommendedInstances,
+		PredictedInstances: predictedInstances,
 	}, nil
 }
 

--- a/app/predictor/predictor.go
+++ b/app/predictor/predictor.go
@@ -16,8 +16,11 @@ type PredictionInput struct {
 
 // PredictionResult contains the output of a prediction.
 type PredictionResult struct {
-	// RecommendedInstances is the recommended number of instances to have available.
-	RecommendedInstances int
+	// PredictedInstances is the recommended base instance count derived from
+	// historical/EMA analysis. MinInstances floors this value. Callers (the scaler)
+	// are responsible for any additional over-provisioning buffer — the predictor
+	// no longer applies ScalePercent.
+	PredictedInstances int
 }
 
 // Predictor defines the interface for predicting the number of machines required.

--- a/app/predictor/predictor_test.go
+++ b/app/predictor/predictor_test.go
@@ -103,8 +103,8 @@ func TestEMAWeekendDecayPredictor_Predict_EmptyHistory(t *testing.T) {
 	}
 
 	// With no historical data, should return minimum instances (0 by default)
-	if result.RecommendedInstances != 0 {
-		t.Errorf("expected minimum instances 0, got %d", result.RecommendedInstances)
+	if result.PredictedInstances != 0 {
+		t.Errorf("expected minimum instances 0, got %d", result.PredictedInstances)
 	}
 }
 
@@ -163,8 +163,8 @@ func TestEMAWeekendDecayPredictor_Predict_WithRecentData(t *testing.T) {
 
 	// Should recommend more than minimum based on historical data
 	// EMA ~12, Historical weighted avg ~11.7, Combined ~11.8, with 10% buffer ~13
-	if result.RecommendedInstances < 10 {
-		t.Errorf("expected recommended instances >= 10, got %d", result.RecommendedInstances)
+	if result.PredictedInstances < 10 {
+		t.Errorf("expected recommended instances >= 10, got %d", result.PredictedInstances)
 	}
 }
 
@@ -231,8 +231,8 @@ func TestEMAWeekendDecayPredictor_Predict_WithHistoricalWeekData(t *testing.T) {
 	// Historical: (20*0.85 + 15*0.10 + 12*0.05) / 1.0 = 19.1
 	// Combined: 0.85*10 + 0.15*19.1 = 11.365
 	// With 15% safety buffer: ~13.07, ceil = 14
-	if result.RecommendedInstances < 10 || result.RecommendedInstances > 25 {
-		t.Errorf("expected recommended instances between 10-25, got %d", result.RecommendedInstances)
+	if result.PredictedInstances < 10 || result.PredictedInstances > 25 {
+		t.Errorf("expected recommended instances between 10-25, got %d", result.PredictedInstances)
 	}
 }
 
@@ -272,7 +272,6 @@ func TestEMAWeekendDecayPredictor_WeekendVsWeekday(t *testing.T) {
 	store := &MockHistoryStore{records: records} //nolint:gocritic
 
 	config := DefaultPredictorConfig()
-	config.ScalePercent = 100 // Disable buffer for easier testing
 
 	predictor := NewEMAWeekendDecayPredictor(store, config)
 
@@ -303,14 +302,14 @@ func TestEMAWeekendDecayPredictor_WeekendVsWeekday(t *testing.T) {
 	}
 
 	// Both should produce valid predictions
-	t.Logf("Saturday (historical only): %d instances", saturdayResult.RecommendedInstances)
-	t.Logf("Tuesday (EMA + historical): %d instances", tuesdayResult.RecommendedInstances)
+	t.Logf("Saturday (historical only): %d instances", saturdayResult.PredictedInstances)
+	t.Logf("Tuesday (EMA + historical): %d instances", tuesdayResult.PredictedInstances)
 
 	// With same historical data, results depend on algorithm differences
 	// Weekend uses only historical, weekday combines EMA with historical
-	if saturdayResult.RecommendedInstances < 1 || tuesdayResult.RecommendedInstances < 1 {
+	if saturdayResult.PredictedInstances < 1 || tuesdayResult.PredictedInstances < 1 {
 		t.Errorf("expected valid predictions, got weekend=%d, weekday=%d",
-			saturdayResult.RecommendedInstances, tuesdayResult.RecommendedInstances)
+			saturdayResult.PredictedInstances, tuesdayResult.PredictedInstances)
 	}
 }
 
@@ -331,7 +330,6 @@ func TestEMAWeekendDecayPredictor_DecayWeights(t *testing.T) {
 
 	store := &MockHistoryStore{records: records} //nolint:gocritic
 	config := DefaultPredictorConfig()
-	config.ScalePercent = 100
 	config.EMAWeight = 0 // Use only historical
 
 	predictor := NewEMAWeekendDecayPredictor(store, config)
@@ -349,8 +347,8 @@ func TestEMAWeekendDecayPredictor_DecayWeights(t *testing.T) {
 	}
 
 	// With only week 1 data at 50 instances, should recommend ~50
-	if result.RecommendedInstances != 50 {
-		t.Errorf("expected 50 instances, got %d", result.RecommendedInstances)
+	if result.PredictedInstances != 50 {
+		t.Errorf("expected 50 instances, got %d", result.PredictedInstances)
 	}
 }
 
@@ -371,9 +369,6 @@ func TestDefaultPredictorConfig(t *testing.T) {
 	}
 	if config.WeekDecayFactors[2] != 0.05 {
 		t.Errorf("expected week 3 decay 0.05, got %f", config.WeekDecayFactors[2])
-	}
-	if config.ScalePercent != 100 {
-		t.Errorf("expected ScalePercent 100, got %f", config.ScalePercent)
 	}
 	if config.MinInstances != 0 {
 		t.Errorf("expected MinInstances 0, got %d", config.MinInstances)
@@ -506,86 +501,7 @@ func TestIsWeekend(t *testing.T) {
 	}
 }
 
-func TestEMAWeekendDecayPredictor_ScalePercent(t *testing.T) {
-	// Wednesday, January 10, 2024 at 10:00 AM UTC
-	now := time.Date(2024, 1, 10, 10, 0, 0, 0, time.UTC)
-
-	// Only add data for 1 week ago so historical value is deterministic
-	records := []types.UtilizationRecord{
-		{
-			Pool:           "test-pool",
-			VariantID:      "variant-1",
-			InUseInstances: 50,
-			RecordedAt:     now.Add(-7 * 24 * time.Hour).Unix(),
-		},
-	}
-
-	tests := []struct {
-		name         string
-		scalePercent float64
-		expected     int
-	}{
-		{
-			name:         "100% returns exact prediction",
-			scalePercent: 100,
-			expected:     50, // 50 * 1.0 = 50
-		},
-		{
-			name:         "150% scales up prediction",
-			scalePercent: 150,
-			expected:     75, // 50 * 1.5 = 75
-		},
-		{
-			name:         "50% scales down prediction",
-			scalePercent: 50,
-			expected:     25, // 50 * 0.5 = 25
-		},
-		{
-			name:         "200% doubles prediction",
-			scalePercent: 200,
-			expected:     100, // doubles prediction
-		},
-		{
-			name:         "115% similar to old 0.15 safety buffer",
-			scalePercent: 115,
-			expected:     58, // 50 * 1.15 = 57.5, ceil = 58
-		},
-		{
-			name:         "80% reduces prediction",
-			scalePercent: 80,
-			expected:     40, // 50 * 0.8 = 40
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockStore := &MockHistoryStore{records: records}
-			config := DefaultPredictorConfig()
-			config.ScalePercent = tt.scalePercent
-			config.EMAWeight = 0 // Use only historical for deterministic results
-
-			pred := NewEMAWeekendDecayPredictor(mockStore, config)
-
-			input := &PredictionInput{
-				PoolName:       "test-pool",
-				VariantID:      "variant-1",
-				StartTimestamp: now.Unix(),
-				EndTimestamp:   now.Add(time.Hour).Unix(),
-			}
-
-			result, err := pred.Predict(context.Background(), input)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if result.RecommendedInstances != tt.expected {
-				t.Errorf("expected %d instances, got %d", tt.expected, result.RecommendedInstances)
-			}
-		})
-	}
-}
-
-func TestEMAWeekendDecayPredictor_ScalePercent_WithMinInstances(t *testing.T) {
+func TestEMAWeekendDecayPredictor_MinInstances(t *testing.T) {
 	// Wednesday, January 10, 2024 at 10:00 AM UTC
 	now := time.Date(2024, 1, 10, 10, 0, 0, 0, time.UTC)
 
@@ -593,15 +509,14 @@ func TestEMAWeekendDecayPredictor_ScalePercent_WithMinInstances(t *testing.T) {
 		{
 			Pool:           "test-pool",
 			VariantID:      "variant-1",
-			InUseInstances: 10,
+			InUseInstances: 3,
 			RecordedAt:     now.Add(-7 * 24 * time.Hour).Unix(),
 		},
 	}
 
 	mockStore := &MockHistoryStore{records: records}
 	config := DefaultPredictorConfig()
-	config.ScalePercent = 50 // 10 * 0.5 = 5
-	config.MinInstances = 8  // But min is 8
+	config.MinInstances = 8 // Floor raises prediction from 3 to 8
 	config.EMAWeight = 0
 
 	pred := NewEMAWeekendDecayPredictor(mockStore, config)
@@ -618,9 +533,8 @@ func TestEMAWeekendDecayPredictor_ScalePercent_WithMinInstances(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// ScalePercent would give 5, but MinInstances enforces 8
-	if result.RecommendedInstances != 8 {
-		t.Errorf("expected MinInstances=8 to take precedence, got %d", result.RecommendedInstances)
+	if result.PredictedInstances != 8 {
+		t.Errorf("expected MinInstances=8 to take precedence, got %d", result.PredictedInstances)
 	}
 }
 
@@ -669,12 +583,12 @@ func TestEMAWeekendDecayPredictor_15MinWindowPrediction(t *testing.T) {
 			t.Fatalf("window %d: unexpected error: %v", i, err)
 		}
 
-		predictions = append(predictions, result.RecommendedInstances)
+		predictions = append(predictions, result.PredictedInstances)
 		t.Logf("Window %d [%s - %s]: Recommended %d instances",
 			i+1,
 			windowStart.Format("15:04"),
 			windowEnd.Format("15:04"),
-			result.RecommendedInstances)
+			result.PredictedInstances)
 	}
 
 	// Validate predictions are reasonable
@@ -741,14 +655,14 @@ func TestEMAWeekendDecayPredictor_15MinWindowWeekdayVsWeekend(t *testing.T) {
 		t.Fatalf("weekend prediction failed: %v", err)
 	}
 
-	t.Logf("Weekday (Wednesday 10:00-10:15): %d instances", weekdayResult.RecommendedInstances)
-	t.Logf("Weekend (Saturday 10:00-10:15): %d instances", weekendResult.RecommendedInstances)
+	t.Logf("Weekday (Wednesday 10:00-10:15): %d instances", weekdayResult.PredictedInstances)
+	t.Logf("Weekend (Saturday 10:00-10:15): %d instances", weekendResult.PredictedInstances)
 
 	// Weekend uses only historical data, weekday uses EMA + historical
 	// Results may vary based on historical patterns
-	if weekendResult.RecommendedInstances >= weekdayResult.RecommendedInstances {
+	if weekendResult.PredictedInstances >= weekdayResult.PredictedInstances {
 		t.Logf("Note: Weekend prediction (%d) >= Weekday prediction (%d)",
-			weekendResult.RecommendedInstances, weekdayResult.RecommendedInstances)
+			weekendResult.PredictedInstances, weekdayResult.PredictedInstances)
 		// This can happen based on historical data patterns
 	}
 }
@@ -796,10 +710,10 @@ func TestEMAWeekendDecayPredictor_15MinWindowWithSpikes(t *testing.T) {
 			i+1,
 			windowStart.Format("15:04"),
 			windowEnd.Format("15:04"),
-			result.RecommendedInstances)
+			result.PredictedInstances)
 
 		// Predictions should account for historical spikes
-		if result.RecommendedInstances < config.MinInstances {
+		if result.PredictedInstances < config.MinInstances {
 			t.Errorf("window %d: prediction below minimum", i)
 		}
 	}
@@ -836,11 +750,11 @@ func TestEMAWeekendDecayPredictor_15MinWindowTrendDetection(t *testing.T) {
 		t.Fatalf("prediction failed: %v", err)
 	}
 
-	t.Logf("Prediction with gradual increase trend: %d instances", result.RecommendedInstances)
+	t.Logf("Prediction with gradual increase trend: %d instances", result.PredictedInstances)
 
 	// With gradual increase, the EMA should capture the upward trend
 	// and recommend higher instances compared to stable data
-	if result.RecommendedInstances < config.MinInstances {
+	if result.PredictedInstances < config.MinInstances {
 		t.Errorf("prediction below minimum")
 	}
 }

--- a/app/scheduler/jobs/scaler.go
+++ b/app/scheduler/jobs/scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -114,7 +115,7 @@ func (s *Scaler) ScalePool(ctx context.Context, poolName string, windowStart, wi
 		return nil
 	}
 
-	// Get current free instance counts for this pool, grouped by (variant, image)
+	// Get current free instance counts for this pool, grouped by (variant, image).
 	freeCounts, err := s.getFreeInstanceCountsForPool(ctx, *targetPool)
 	if err != nil {
 		return fmt.Errorf("scaler: failed to get free instance counts: %w", err)
@@ -212,19 +213,20 @@ func (s *Scaler) scaleVariant(
 		return fmt.Errorf("failed to get prediction: %w", err)
 	}
 
-	// Get current free count for this instance key combination
 	key := InstanceKey{VariantID: variantID, ImageName: imageName}
 	currentFree := freeCounts[key]
 
-	// Ensure we never go below min size
-	targetCount := prediction.RecommendedInstances
+	// Target = predicted demand, floored by MinSize.
+	targetCount := prediction.PredictedInstances
 	if targetCount < minSize {
 		targetCount = minSize
 	}
 
-	// If prediction is 0 but there was recent usage, apply a minimum floor
+	// If prediction is 0 but there was recent usage, apply a minimum floor.
+	// These extra instances are kept hibernated (warm-standby) since there's no
+	// predicted demand — only past usage justifying a small floor.
 	scaledByRecentUsage := false
-	if prediction.RecommendedInstances == 0 && s.config.RecentUsageMinInstances > 0 {
+	if prediction.PredictedInstances == 0 && s.config.RecentUsageMinInstances > 0 {
 		hasRecentUsage, checkErr := s.hasRecentUsage(ctx, pool.Name, variantID, imageName)
 		if checkErr != nil {
 			logr.WithError(checkErr).Warnln("scaler: failed to check recent usage, skipping recent usage minimum")
@@ -236,17 +238,25 @@ func (s *Scaler) scaleVariant(
 
 	delta := targetCount - currentFree
 
-	logr.WithFields(logrus.Fields{
-		"current_free": currentFree,
-		"predicted":    prediction.RecommendedInstances,
-		"target":       targetCount,
-		"min_size":     minSize,
-		"delta":        delta,
-	}).Infoln("scaler: calculated scaling delta")
+	// Compute hibernated buffer only for positive deltas, applied as a percentage of the delta.
+	bufferDelta := 0
+	if delta > 0 && s.config.ScalePercent > 100 {
+		bufferDelta = int(math.Ceil(float64(delta) * (s.config.ScalePercent - 100.0) / 100.0)) //nolint:mnd
+	}
 
-	// Record metrics
+	logr.WithFields(logrus.Fields{
+		"current_free":           currentFree,
+		"predicted":              prediction.PredictedInstances,
+		"target":                 targetCount,
+		"min_size":               minSize,
+		"delta":                  delta,
+		"buffer_delta":           bufferDelta,
+		"scale_percent":          s.config.ScalePercent,
+		"scaled_by_recent_usage": scaledByRecentUsage,
+	}).Infoln("scaler: calculated scaling deltas")
+
 	if s.metrics != nil {
-		s.metrics.ScalerPredictedInstances.WithLabelValues(pool.Name, variantID, imageName).Set(float64(prediction.RecommendedInstances))
+		s.metrics.ScalerPredictedInstances.WithLabelValues(pool.Name, variantID, imageName).Set(float64(targetCount + bufferDelta))
 	}
 
 	// If dry run mode is enabled, only record metrics and skip actual scaling
@@ -256,10 +266,12 @@ func (s *Scaler) scaleVariant(
 	}
 
 	if delta > 0 {
-		// Scale up: create instances
+		// Recent-usage-floored instances are hibernated; normal predicted demand is live.
 		s.scaleUp(ctx, pool, variantID, imageName, params, delta, scaledByRecentUsage)
+		if bufferDelta > 0 {
+			s.scaleUp(ctx, pool, variantID, imageName, params, bufferDelta, true)
+		}
 	} else if delta < 0 {
-		// Scale down: destroy excess instances
 		s.scaleDown(ctx, pool.Name, variantID, imageName, -delta)
 	}
 
@@ -333,7 +345,7 @@ func (s *Scaler) scaleUp(
 	}
 }
 
-// scaleDown destroys excess free instances.
+// scaleDown destroys excess free instances (either live or hibernated).
 func (s *Scaler) scaleDown(
 	ctx context.Context,
 	poolName, variantID, imageName string,
@@ -358,7 +370,6 @@ func (s *Scaler) scaleDown(
 	}
 
 	allowedStates := []types.InstanceState{types.StateCreated, types.StateHibernating}
-
 	destroyedCount := 0
 	for i := 0; i < count; i++ {
 		// Atomically find and claim a free instance, setting it to terminating state
@@ -391,7 +402,10 @@ func (s *Scaler) scaleDown(
 }
 
 // getFreeInstanceCountsForPool returns free instance counts keyed by InstanceKey for a specific pool.
-func (s *Scaler) getFreeInstanceCountsForPool(ctx context.Context, pool ScalablePool) (map[InstanceKey]int, error) {
+// Free instances are those in StateCreated, StateHibernating, or StateProvisioning.
+func (s *Scaler) getFreeInstanceCountsForPool(ctx context.Context, pool ScalablePool) (
+	map[InstanceKey]int, error,
+) {
 	instances, err := s.instanceStore.List(ctx, pool.Name, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list instances for pool %s: %w", pool.Name, err)

--- a/app/scheduler/jobs/scaler.go
+++ b/app/scheduler/jobs/scaler.go
@@ -63,7 +63,7 @@ func NewScaler(
 	instanceStore store.InstanceStore,
 	historyStore store.UtilizationHistoryStore,
 	outboxStore store.OutboxStore,
-	config types.ScalerConfig,
+	config types.ScalerConfig, //nolint:gocritic // acceptable for one-time setup
 	pools []ScalablePool,
 	metrics *metric.Metrics,
 ) *Scaler {

--- a/app/scheduler/jobs/scaler_test.go
+++ b/app/scheduler/jobs/scaler_test.go
@@ -14,29 +14,30 @@ import (
 
 // MockPredictor is a mock implementation of predictor.Predictor for testing.
 type MockPredictor struct {
-	predictions map[string]int // key: "poolName:variantID:imageName" -> predicted instances
+	predictions map[string]predictor.PredictionResult // key: "poolName:variantID:imageName"
 }
 
 func NewMockPredictor() *MockPredictor {
 	return &MockPredictor{
-		predictions: make(map[string]int),
+		predictions: make(map[string]predictor.PredictionResult),
 	}
 }
 
 func (m *MockPredictor) SetPrediction(poolName, variantID string, instances int) {
-	m.predictions[poolName+":"+variantID+":"] = instances
+	m.predictions[poolName+":"+variantID+":"] = predictor.PredictionResult{PredictedInstances: instances}
 }
 
 func (m *MockPredictor) SetPredictionForImage(poolName, variantID, imageName string, instances int) {
-	m.predictions[poolName+":"+variantID+":"+imageName] = instances
+	m.predictions[poolName+":"+variantID+":"+imageName] = predictor.PredictionResult{PredictedInstances: instances}
 }
 
 func (m *MockPredictor) Predict(ctx context.Context, input *predictor.PredictionInput) (*predictor.PredictionResult, error) {
 	key := input.PoolName + ":" + input.VariantID + ":" + input.ImageName
-	if instances, ok := m.predictions[key]; ok {
-		return &predictor.PredictionResult{RecommendedInstances: instances}, nil
+	if result, ok := m.predictions[key]; ok {
+		r := result
+		return &r, nil
 	}
-	return &predictor.PredictionResult{RecommendedInstances: 1}, nil
+	return &predictor.PredictionResult{PredictedInstances: 1}, nil
 }
 
 func (m *MockPredictor) Name() string {
@@ -1306,5 +1307,210 @@ func TestScaler_ScaleDown_FiltersPredictor(t *testing.T) {
 	)
 	if err == nil {
 		t.Error("expected error when no more predictor instances, got nil")
+	}
+}
+
+// TestScaler_ScalePercent_CreatesHibernatedBuffer verifies that when ScalePercent > 100
+// and there's a positive delta, the scaler creates additional hibernated VMs equal to
+// ceil(delta * (ScalePercent-100)/100).
+func TestScaler_ScalePercent_CreatesHibernatedBuffer(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+	outboxStore := NewMockOutboxStore()
+	mockPredictor := NewMockPredictor()
+	historyStore := NewMockUtilizationHistoryStore()
+
+	// Predict 10 instances, current free = 0, delta = 10.
+	// ScalePercent = 120 -> buffer = ceil(10 * 20 / 100) = 2 hibernated VMs.
+	mockPredictor.SetPredictionForImage("pool-1", "default", "ubuntu-2204", 10)
+
+	historyStore.records = append(historyStore.records, types.UtilizationRecord{
+		Pool: "pool-1", VariantID: "default", ImageName: "ubuntu-2204",
+		RecordedAt: time.Now().Unix(), InUseInstances: 1,
+	})
+
+	pools := []ScalablePool{{Name: "pool-1", MinSize: 1}}
+
+	config := types.ScalerConfig{
+		WindowDuration: 30 * time.Minute,
+		LeadTime:       5 * time.Minute,
+		Enabled:        true,
+		ScalePercent:   120,
+	}
+
+	scaler := NewScaler(nil, mockPredictor, instanceStore, historyStore, outboxStore, config, pools, nil)
+
+	now := time.Now()
+	if err := scaler.ScalePool(context.Background(), "pool-1", now.Unix(), now.Add(30*time.Minute).Unix()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	setupJobs := outboxStore.GetJobsByType(types.OutboxJobTypeSetupInstance)
+	if len(setupJobs) != 12 {
+		t.Fatalf("expected 12 setup jobs (10 live + 2 hibernated buffer), got %d", len(setupJobs))
+	}
+
+	liveCount, hibernatedCount := 0, 0
+	for _, job := range setupJobs {
+		var params types.SetupInstanceParams
+		if err := json.Unmarshal(*job.JobParams, &params); err != nil {
+			t.Fatalf("failed to unmarshal job params: %v", err)
+		}
+		if params.Hibernate {
+			hibernatedCount++
+		} else {
+			liveCount++
+		}
+	}
+
+	if liveCount != 10 {
+		t.Errorf("expected 10 live jobs, got %d", liveCount)
+	}
+	if hibernatedCount != 2 {
+		t.Errorf("expected 2 hibernated buffer jobs, got %d", hibernatedCount)
+	}
+}
+
+// TestScaler_ScalePercent_NotAppliedWhenDeltaIsZero verifies that when the delta
+// is zero (current free already meets prediction), no hibernated buffer is created.
+func TestScaler_ScalePercent_NotAppliedWhenDeltaIsZero(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+	outboxStore := NewMockOutboxStore()
+	mockPredictor := NewMockPredictor()
+	historyStore := NewMockUtilizationHistoryStore()
+
+	mockPredictor.SetPredictionForImage("pool-1", "default", "ubuntu-2204", 5)
+
+	// 5 free instances already exist — delta = 0
+	for i := 0; i < 5; i++ {
+		instanceStore.AddInstance(&types.Instance{
+			ID:        "inst-" + time.Now().Format("150405") + string(rune(i)),
+			Pool:      "pool-1",
+			VariantID: "default",
+			Image:     "ubuntu-2204",
+			State:     types.StateCreated,
+		})
+	}
+
+	historyStore.records = append(historyStore.records, types.UtilizationRecord{
+		Pool: "pool-1", VariantID: "default", ImageName: "ubuntu-2204",
+		RecordedAt: time.Now().Unix(), InUseInstances: 1,
+	})
+
+	pools := []ScalablePool{{Name: "pool-1", MinSize: 1}}
+
+	config := types.ScalerConfig{
+		WindowDuration: 30 * time.Minute,
+		LeadTime:       5 * time.Minute,
+		Enabled:        true,
+		ScalePercent:   150,
+	}
+
+	scaler := NewScaler(nil, mockPredictor, instanceStore, historyStore, outboxStore, config, pools, nil)
+
+	now := time.Now()
+	if err := scaler.ScalePool(context.Background(), "pool-1", now.Unix(), now.Add(30*time.Minute).Unix()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	setupJobs := outboxStore.GetJobsByType(types.OutboxJobTypeSetupInstance)
+	if len(setupJobs) != 0 {
+		t.Errorf("expected 0 jobs when delta is 0, got %d", len(setupJobs))
+	}
+}
+
+// TestScaler_ScalePercent_Disabled_At100 verifies that ScalePercent <= 100 creates
+// no hibernated buffer, regardless of delta.
+func TestScaler_ScalePercent_Disabled_At100(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+	outboxStore := NewMockOutboxStore()
+	mockPredictor := NewMockPredictor()
+	historyStore := NewMockUtilizationHistoryStore()
+
+	mockPredictor.SetPredictionForImage("pool-1", "default", "ubuntu-2204", 7)
+	historyStore.records = append(historyStore.records, types.UtilizationRecord{
+		Pool: "pool-1", VariantID: "default", ImageName: "ubuntu-2204",
+		RecordedAt: time.Now().Unix(), InUseInstances: 1,
+	})
+
+	pools := []ScalablePool{{Name: "pool-1", MinSize: 1}}
+
+	config := types.ScalerConfig{
+		WindowDuration: 30 * time.Minute,
+		LeadTime:       5 * time.Minute,
+		Enabled:        true,
+		ScalePercent:   100,
+	}
+
+	scaler := NewScaler(nil, mockPredictor, instanceStore, historyStore, outboxStore, config, pools, nil)
+
+	now := time.Now()
+	if err := scaler.ScalePool(context.Background(), "pool-1", now.Unix(), now.Add(30*time.Minute).Unix()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	setupJobs := outboxStore.GetJobsByType(types.OutboxJobTypeSetupInstance)
+	if len(setupJobs) != 7 {
+		t.Fatalf("expected 7 live jobs, got %d", len(setupJobs))
+	}
+
+	for _, job := range setupJobs {
+		var params types.SetupInstanceParams
+		if err := json.Unmarshal(*job.JobParams, &params); err != nil {
+			t.Fatalf("failed to unmarshal job params: %v", err)
+		}
+		if params.Hibernate {
+			t.Errorf("expected no hibernated jobs when ScalePercent=100, got one: %+v", params)
+		}
+	}
+}
+
+// TestScaler_ScalePercent_CeilingRounding verifies the ceiling rounding behavior
+// for fractional buffer deltas.
+func TestScaler_ScalePercent_CeilingRounding(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+	outboxStore := NewMockOutboxStore()
+	mockPredictor := NewMockPredictor()
+	historyStore := NewMockUtilizationHistoryStore()
+
+	// delta = 3, ScalePercent = 115 -> buffer = ceil(3 * 0.15) = ceil(0.45) = 1
+	mockPredictor.SetPredictionForImage("pool-1", "default", "ubuntu-2204", 3)
+	historyStore.records = append(historyStore.records, types.UtilizationRecord{
+		Pool: "pool-1", VariantID: "default", ImageName: "ubuntu-2204",
+		RecordedAt: time.Now().Unix(), InUseInstances: 1,
+	})
+
+	pools := []ScalablePool{{Name: "pool-1", MinSize: 1}}
+
+	config := types.ScalerConfig{
+		WindowDuration: 30 * time.Minute,
+		LeadTime:       5 * time.Minute,
+		Enabled:        true,
+		ScalePercent:   115,
+	}
+
+	scaler := NewScaler(nil, mockPredictor, instanceStore, historyStore, outboxStore, config, pools, nil)
+
+	now := time.Now()
+	if err := scaler.ScalePool(context.Background(), "pool-1", now.Unix(), now.Add(30*time.Minute).Unix()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	setupJobs := outboxStore.GetJobsByType(types.OutboxJobTypeSetupInstance)
+	if len(setupJobs) != 4 {
+		t.Fatalf("expected 4 jobs (3 live + 1 ceil buffer), got %d", len(setupJobs))
+	}
+
+	hibernatedCount := 0
+	for _, job := range setupJobs {
+		var params types.SetupInstanceParams
+		if err := json.Unmarshal(*job.JobParams, &params); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+		if params.Hibernate {
+			hibernatedCount++
+		}
+	}
+	if hibernatedCount != 1 {
+		t.Errorf("expected 1 hibernated buffer job, got %d", hibernatedCount)
 	}
 }

--- a/app/scheduler/jobs/scaler_trigger.go
+++ b/app/scheduler/jobs/scaler_trigger.go
@@ -29,7 +29,7 @@ type ScalerTriggerJob struct {
 // NewScalerTriggerJob creates a new ScalerTriggerJob.
 func NewScalerTriggerJob(
 	outboxStore store.OutboxStore,
-	config types.ScalerConfig,
+	config types.ScalerConfig, //nolint:gocritic // acceptable for one-time setup
 	runnerName string,
 	pools []ScalablePool,
 ) *ScalerTriggerJob {

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -428,11 +428,11 @@ type EnvConfig struct {
 			ActiveImageLookbackDays int      `envconfig:"DLITE_SCHEDULER_SCALER_ACTIVE_IMAGE_LOOKBACK_DAYS" default:"2"`
 			RecentUsageLookbackDays int      `envconfig:"DLITE_SCHEDULER_SCALER_RECENT_USAGE_LOOKBACK_DAYS" default:"7"`
 			RecentUsageMinInstances int      `envconfig:"DLITE_SCHEDULER_SCALER_RECENT_USAGE_MIN_INSTANCES" default:"0"`
+			ScalePercent            float64  `envconfig:"DLITE_SCHEDULER_SCALER_SCALE_PERCENT" default:"100"`
 		}
 		Predictor struct {
 			EMAPeriod       int     `envconfig:"DLITE_PREDICTOR_EMA_PERIOD" default:"3"`
 			EMAWeight       float64 `envconfig:"DLITE_PREDICTOR_EMA_WEIGHT" default:"0.85"`
-			ScalePercent    float64 `envconfig:"DLITE_PREDICTOR_SCALE_PERCENT" default:"100"`
 			MinInstances    int     `envconfig:"DLITE_PREDICTOR_MIN_INSTANCES" default:"0"`
 			MaxLookbackDays int     `envconfig:"DLITE_PREDICTOR_MAX_LOOKBACK_DAYS" default:"4"`
 			TargetWeekdays  int     `envconfig:"DLITE_PREDICTOR_TARGET_WEEKDAYS" default:"2"`

--- a/command/harness/distributed.go
+++ b/command/harness/distributed.go
@@ -124,6 +124,7 @@ func SetupDistributedMode(cfg DistributedSetupConfig) (*DistributedSetupResult, 
 			ActiveImageLookbackDays: cfg.Env.Scheduler.Scaler.ActiveImageLookbackDays,
 			RecentUsageLookbackDays: cfg.Env.Scheduler.Scaler.RecentUsageLookbackDays,
 			RecentUsageMinInstances: cfg.Env.Scheduler.Scaler.RecentUsageMinInstances,
+			ScalePercent:            cfg.Env.Scheduler.Scaler.ScalePercent,
 		}
 
 		// Build scalable pools from pool config
@@ -134,7 +135,6 @@ func SetupDistributedMode(cfg DistributedSetupConfig) (*DistributedSetupResult, 
 			EMAPeriod:        cfg.Env.Scheduler.Predictor.EMAPeriod,
 			EMAWeight:        cfg.Env.Scheduler.Predictor.EMAWeight,
 			WeekDecayFactors: cfg.Env.PredictorConfig(),
-			ScalePercent:     cfg.Env.Scheduler.Predictor.ScalePercent,
 			MinInstances:     cfg.Env.Scheduler.Predictor.MinInstances,
 			MaxLookbackDays:  cfg.Env.Scheduler.Predictor.MaxLookbackDays,
 			TargetWeekdays:   cfg.Env.Scheduler.Predictor.TargetWeekdays,

--- a/types/types.go
+++ b/types/types.go
@@ -398,6 +398,11 @@ type ScalerConfig struct {
 	// This is applied on top of minSize: if RecentUsageMinInstances=3 and minSize=2,
 	// only 1 additional instance is added. Default: 0 (disabled)
 	RecentUsageMinInstances int
+	// ScalePercent is the percentage of additional instances to pre-provision as a hibernated
+	// buffer above the predicted live demand. It is only applied to positive scale-up deltas.
+	// A value of 100 (or below) disables buffering; 115 adds a 15% hibernated buffer on top
+	// of the live scale-up. Default: 100 (disabled).
+	ScalePercent float64
 }
 
 // InstanceCount holds an instance count grouped by pool, variant, image, and GPU flag.


### PR DESCRIPTION
## Summary
- Predictor no longer applies `ScalePercent`; it returns just `PredictedInstances`.
- Scaler now owns `ScalePercent` and applies it only to *positive* scale-up deltas. The buffer portion is always created as **hibernated** VMs, while the base predicted demand is created live.
- Recent-usage-floor instances (when `prediction == 0` but `RecentUsageMinInstances > 0`) are hibernated, matching prior behavior.
- Env var renamed: `DLITE_PREDICTOR_SCALE_PERCENT` → `DLITE_SCHEDULER_SCALER_SCALE_PERCENT`.

## Root Cause
`EMAWeekendDecayPredictor.Predict()` previously applied `ScalePercent` internally and returned a single aggregated count. The scaler could not distinguish the raw predicted demand from the buffer added by `ScalePercent`, so it could not treat the buffered portion differently (e.g., always hibernate to save cost while keeping the base capacity live).

## Changes
- `app/predictor/predictor.go`: `PredictionResult` returns only `PredictedInstances`.
- `app/predictor/ema_weekend_decay_predictor.go`: `PredictorConfig.ScalePercent` removed; `Predict()` no longer applies the multiplier.
- `types/types.go`: `ScalerConfig.ScalePercent` added.
- `app/scheduler/jobs/scaler.go`: new delta-based buffer logic — `bufferDelta = ceil(delta * (ScalePercent-100)/100)` for `delta > 0`, created hibernated. `scaledByRecentUsage` preserved.
- `command/config/config.go`, `command/harness/distributed.go`: env plumbing moved from Predictor → Scaler.

## Testing
- Updated `app/predictor/predictor_test.go` (removed ScalePercent tests from predictor, replaced with `MinInstances` test).
- Added 4 new scaler tests covering:
  - `TestScaler_ScalePercent_CreatesHibernatedBuffer` — 120% on delta=10 yields 10 live + 2 hibernated.
  - `TestScaler_ScalePercent_NotAppliedWhenDeltaIsZero` — no buffer when scale-up is unnecessary.
  - `TestScaler_ScalePercent_Disabled_At100` — no buffer when ScalePercent ≤ 100.
  - `TestScaler_ScalePercent_CeilingRounding` — fractional buffers round up.
- `go build ./... && go test ./... && go vet ./...` all pass.

## Ticket
[CI-22129](https://harness.atlassian.net/browse/CI-22129)

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-22129]: https://harness.atlassian.net/browse/CI-22129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ