### PR TITLE
fix: [CI-21780]: skip InvalidInstanceID.NotFound and make bootstrap cleanup non-fatal

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -808,11 +808,18 @@ func (p *amazonConfig) DestroyInstanceAndStorage(
 
 		_, err := client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{InstanceIds: []string{instance.ID}})
 		if err != nil {
-			err = fmt.Errorf("failed to terminate instance %s: %v", instance.ID, err)
-			logr.Error(err)
-			failedInstances = append(failedInstances, instance)
-			lastErr = err
-			continue
+			// Instance already gone in AWS — treat as successfully destroyed so the
+			// DB row gets cleaned up instead of resurfacing on every startup cleanup.
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == "InvalidInstanceID.NotFound" {
+				logr.WithError(err).Warnln("amazon: instance not found in AWS, treating as already terminated")
+			} else {
+				err = fmt.Errorf("failed to terminate instance %s: %v", instance.ID, err)
+				logr.Error(err)
+				failedInstances = append(failedInstances, instance)
+				lastErr = err
+				continue
+			}
 		}
 
 		logr.Traceln("amazon: VM terminated")

--- a/command/harness/pool.go
+++ b/command/harness/pool.go
@@ -57,13 +57,15 @@ func SetupPool(
 			Errorln("failed to start instance purger")
 		return configPool, err
 	}
-	// lets remove any old instances.
+	// lets remove any old instances. Bootstrap cleanup is best-effort: log and
+	// continue so transient AWS/GCP errors don't crash-loop the runner on startup.
 	if !reusePool {
 		cleanErr := poolManager.CleanPools(ctx, true, true)
 		if cleanErr != nil {
-			return configPool, cleanErr
+			logrus.WithError(cleanErr).Warnln("bootstrap pool cleanup failed; continuing startup")
+		} else {
+			logrus.Infoln("pools cleaned")
 		}
-		logrus.Infoln("pools cleaned")
 	}
 	// seed pools
 	buildPoolErr := poolManager.BuildPools(ctx)


### PR DESCRIPTION
## Problem

After PR #813 merged (rc.271), customers reported that the drone-runner container began crash-looping on startup. Deleting the SQLite DB file restored health. Attached logs show ~106 restart cycles, each ~33s apart, all failing on the same 9 stale instances.

## Root Cause

When the runner restarts with stale instance rows in SQLite whose AWS instances are already gone:

1. `SetupPool` → `poolManager.CleanPools` → purger `cleanPool` → amazon `DestroyInstanceAndStorage`
2. `ec2.TerminateInstances` returns `InvalidInstanceID.NotFound`
3. Driver treats this as failure and appends the instance to `failedInstances`
4. `cleanPool` skips the DB delete for failed instances and returns `failed to destroy N instance(s)`
5. `SetupPool` propagates the error → container exits → supervisor restarts → same rows retry → loop

## Solution

Two best-effort changes:

- **`app/drivers/amazon/driver.go`** — In `DestroyInstanceAndStorage`, detect `InvalidInstanceID.NotFound` via `smithy.APIError` and treat it as already-terminated. The DB row is then cleaned up in the normal path instead of resurfacing every startup. Mirrors the pattern already used in the Google driver (`ErrInstanceNotFound`).
- **`command/harness/pool.go`** — Make bootstrap `CleanPools` best-effort: log the error and continue startup rather than aborting. Transient AWS/GCP errors during bootstrap should not crash-loop the runner.

## Changes

- `app/drivers/amazon/driver.go`: skip `InvalidInstanceID.NotFound` on TerminateInstances
- `command/harness/pool.go`: bootstrap cleanup logs a warning instead of returning an error

## Testing

- `go build ./...` — clean
- `go vet ./app/drivers/amazon/... ./command/harness/...` — clean
- `go test ./app/drivers/amazon/... ./command/harness/...` — pass

## Related

- JIRA: CI-21780
- Prior fix (introduced the stale-row surface): #813
- Customer logs: 106 crash-loop cycles reproducing the issue

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*