### PR TITLE
fix: [CI-22293]: retry before DB delete in distributed purger

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -902,7 +902,7 @@ func (d *DistributedManager) cleanupBusyInstances(ctx context.Context, pool *poo
 		squirrel.Lt{"instance_updated": currentTime.Add(-stuckTerminatingMaxAge).Unix()},
 	}
 	conditions = append(conditions, busyCondition, extendedBusyCondition, stuckTerminatingCondition)
-	_, err := d.executeInstanceCleanup(ctx, pool, conditions, "busy")
+	_, err := d.executeInstanceCleanup(ctx, pool, conditions, "busy", maxAgeBusy)
 	return err
 }
 
@@ -934,7 +934,7 @@ func (d *DistributedManager) cleanupFreeInstances(ctx context.Context, pool *poo
 	conditions := squirrel.Or{freeCondition, stuckProvisioningCondition}
 
 	// Execute cleanup and call setupInstanceAsync for each cleaned instance
-	instances, err := d.executeInstanceCleanup(ctx, pool, conditions, "free")
+	instances, err := d.executeInstanceCleanup(ctx, pool, conditions, "free", maxAgeFree)
 
 	// Log the instances that are being cleaned up
 	// Don't replenish the stale free instances, predictor will handle that
@@ -1025,19 +1025,48 @@ func (d *DistributedManager) cleanupCapacities(ctx context.Context, pool *poolEn
 	d.destroyCapacityFromReservation(ctx, capacitiesToDelete)
 }
 
-// executeInstanceCleanup performs cleanup and returns the instances for further processing
-func (d *DistributedManager) executeInstanceCleanup(ctx context.Context, pool *poolEntry, conditions squirrel.Or, cleanupType string) ([]*types.Instance, error) {
+// executeInstanceCleanup claims candidate rows into StateTerminating, asks the
+// driver to destroy them, and only deletes the DB rows that were destroyed
+// successfully. Rows whose destroy fails stay in StateTerminating and will be
+// re-picked on the next tick via the stuckTerminatingCondition, which gives
+// the driver multiple natural retries. As a safety net to keep the table
+// bounded, rows older than 2 * maxAge by instance_started are force-deleted
+// with an instance_leak_candidate warn log.
+func (d *DistributedManager) executeInstanceCleanup(
+	ctx context.Context,
+	pool *poolEntry,
+	conditions squirrel.Or,
+	cleanupType string,
+	maxAge time.Duration,
+) ([]*types.Instance, error) {
 	logr := logger.FromContext(ctx).
 		WithField("driver", pool.Driver.DriverName()).
 		WithField("pool", pool.Name).
 		WithField("cleanup_type", cleanupType)
+
+	// Force-delete rows that have exceeded 2 * maxAge. They have been retried
+	// for at least the full maxAge window and the driver still hasn't been
+	// able to destroy them; keeping them forever would grow the table
+	// unboundedly. We cap losses by logging loudly.
+	d.forceDeleteLeakedInstances(ctx, pool, cleanupType, maxAge)
+
 	builder := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
-	deleteSQL, args, err := builder.Delete("instances").Where(conditions).Suffix("RETURNING instance_id, instance_name, instance_node_id, runner_name").ToSql()
+	// Claim the rows by transitioning them to StateTerminating. The row stays
+	// in the DB until the driver confirms destroy; this is the inverse of the
+	// previous DELETE-then-destroy path which leaked GCP VMs when Destroy
+	// failed with anything other than NotFound.
+	claimSQL, args, err := builder.
+		Update("instances").
+		Set("instance_state", types.StateTerminating).
+		Set("instance_updated", squirrel.Expr("extract(epoch FROM now())")).
+		Where(conditions).
+		Suffix("RETURNING instance_id, instance_name, instance_node_id, runner_name").
+		ToSql()
 	if err != nil {
 		return nil, err
 	}
 
-	instances, err := d.instanceStore.DeleteAndReturn(ctx, deleteSQL, args...)
+	instances, err := d.instanceStore.DeleteAndReturn(ctx, claimSQL, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1066,16 +1095,99 @@ func (d *DistributedManager) executeInstanceCleanup(ctx context.Context, pool *p
 		failedIDs[inst.ID] = true
 	}
 
-	// Only destroy capacity for successfully deleted instances
 	var successfulInstances []*types.Instance
+	var successfulIDs []string
 	for _, inst := range instances {
-		if !failedIDs[inst.ID] {
-			successfulInstances = append(successfulInstances, inst)
+		if failedIDs[inst.ID] {
+			continue
+		}
+		successfulInstances = append(successfulInstances, inst)
+		successfulIDs = append(successfulIDs, inst.ID)
+	}
+
+	if len(failedIDs) > 0 {
+		failedList := make([]string, 0, len(failedIDs))
+		for id := range failedIDs {
+			failedList = append(failedList, id)
+		}
+		logr.WithField("failed_instance_ids", failedList).
+			WithField("destroy_caller", "distributed_purger:"+cleanupType).
+			Warnf("distributed dlite: purger: %d instance(s) destroy failed; left in terminating for retry", len(failedIDs))
+	}
+
+	if len(successfulIDs) > 0 {
+		deleteSQL, deleteArgs, buildErr := builder.
+			Delete("instances").
+			Where(squirrel.Eq{"instance_id": successfulIDs}).
+			Suffix("RETURNING instance_id, instance_name, instance_node_id, runner_name").
+			ToSql()
+		if buildErr != nil {
+			return successfulInstances, fmt.Errorf("failed to build delete query for destroyed instances: %w", buildErr)
+		}
+		if _, deleteErr := d.instanceStore.DeleteAndReturn(ctx, deleteSQL, deleteArgs...); deleteErr != nil {
+			return successfulInstances, fmt.Errorf("failed to delete destroyed %s instances: %w", cleanupType, deleteErr)
 		}
 	}
 
 	d.destroyCapacity(ctx, successfulInstances)
 	return successfulInstances, nil
+}
+
+// forceDeleteLeakedInstances removes rows that have been stuck past 2 * maxAge.
+// These are instances the driver has been unable to destroy across many retry
+// ticks; keeping them forever would bloat the table and skew pool metrics.
+// We log loudly so operators can reconcile the cloud side.
+func (d *DistributedManager) forceDeleteLeakedInstances(
+	ctx context.Context,
+	pool *poolEntry,
+	cleanupType string,
+	maxAge time.Duration,
+) {
+	if maxAge <= 0 {
+		return
+	}
+	logr := logger.FromContext(ctx).
+		WithField("driver", pool.Driver.DriverName()).
+		WithField("pool", pool.Name).
+		WithField("cleanup_type", cleanupType)
+
+	leakCutoff := time.Now().Add(-2 * maxAge).Unix()
+	builder := squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
+	deleteSQL, args, err := builder.
+		Delete("instances").
+		Where(squirrel.And{
+			squirrel.Eq{"instance_pool": pool.Name},
+			squirrel.Lt{"instance_started": leakCutoff},
+		}).
+		Suffix("RETURNING instance_id, instance_name, instance_node_id, runner_name").
+		ToSql()
+	if err != nil {
+		logr.WithError(err).Error("distributed dlite: purger: failed to build leak-candidate delete query")
+		return
+	}
+
+	leaked, err := d.instanceStore.DeleteAndReturn(ctx, deleteSQL, args...)
+	if err != nil {
+		logr.WithError(err).Error("distributed dlite: purger: failed to force-delete leak-candidate instances")
+		return
+	}
+	if len(leaked) == 0 {
+		return
+	}
+
+	leakedIDs := make([]string, len(leaked))
+	leakedNames := make([]string, len(leaked))
+	for i, inst := range leaked {
+		leakedIDs[i] = inst.ID
+		leakedNames[i] = inst.Name
+	}
+	logr.WithField("instance_ids", leakedIDs).
+		WithField("instance_names", leakedNames).
+		WithField("max_age_seconds", int64(maxAge.Seconds())).
+		WithField("destroy_caller", "distributed_purger:leak_candidate").
+		Warnf("distributed dlite: purger: force-deleting %d instance_leak_candidate row(s) older than 2x maxAge; verify cloud-side cleanup", len(leaked))
+
+	d.destroyCapacity(ctx, leaked)
 }
 
 func (d *DistributedManager) destroyCapacity(ctx context.Context, instances []*types.Instance) {

--- a/app/drivers/distributed_manager_purger_test.go
+++ b/app/drivers/distributed_manager_purger_test.go
@@ -123,7 +123,8 @@ func (s *purgerFakeStore) DeleteAndReturn(_ context.Context, query string, args 
 
 // newPurgerTestManager wires a DistributedManager around the in-memory store
 // and a driver the test can configure per-scenario.
-func newPurgerTestManager(store *purgerFakeStore, driver *flexibleMockDriver, poolName string) (*DistributedManager, *poolEntry) {
+func newPurgerTestManager(store *purgerFakeStore, driver *flexibleMockDriver) (*DistributedManager, *poolEntry) {
+	const poolName = "pool1"
 	pool := &poolEntry{
 		Pool: Pool{
 			Name:   poolName,
@@ -161,7 +162,7 @@ func TestDistributedPurger_ExecuteInstanceCleanup_HappyPath(t *testing.T) {
 		},
 	}
 
-	d, pool := newPurgerTestManager(store, driver, "pool1")
+	d, pool := newPurgerTestManager(store, driver)
 	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
 
 	successful, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
@@ -197,7 +198,7 @@ func TestDistributedPurger_ExecuteInstanceCleanup_DestroyFailureKeepsRow(t *test
 		},
 	}
 
-	d, pool := newPurgerTestManager(store, driver, "pool1")
+	d, pool := newPurgerTestManager(store, driver)
 	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
 
 	successful, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
@@ -238,7 +239,7 @@ func TestDistributedPurger_ForceDeleteLeakCandidateAt2xMaxAge(t *testing.T) {
 		},
 	}
 
-	d, pool := newPurgerTestManager(store, driver, "pool1")
+	d, pool := newPurgerTestManager(store, driver)
 	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
 
 	_, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
@@ -263,7 +264,7 @@ func TestDistributedPurger_ForceDelete_NoopWhenMaxAgeZero(t *testing.T) {
 		&types.Instance{ID: "old", Name: "vm-old", Pool: "pool1", State: types.StateInUse, Started: now.Add(-24 * time.Hour).Unix()},
 	)
 	driver := &flexibleMockDriver{driverName: "mock"}
-	d, pool := newPurgerTestManager(store, driver, "pool1")
+	d, pool := newPurgerTestManager(store, driver)
 
 	d.forceDeleteLeakedInstances(context.Background(), pool, "busy", 0)
 
@@ -295,7 +296,7 @@ func TestDistributedPurger_StuckTerminatingRowIsRePicked(t *testing.T) {
 		},
 	}
 
-	d, pool := newPurgerTestManager(store, driver, "pool1")
+	d, pool := newPurgerTestManager(store, driver)
 	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
 
 	// Tick 1: Destroy fails -> row stays in terminating.

--- a/app/drivers/distributed_manager_purger_test.go
+++ b/app/drivers/distributed_manager_purger_test.go
@@ -1,0 +1,313 @@
+// Copyright 2020 Drone.IO Inc. All rights reserved.
+// Use of this source code is governed by the Polyform License
+// that can be found in the LICENSE file.
+
+package drivers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+// purgerFakeStore is an in-memory fake that understands the three raw SQL
+// statements the distributed purger emits: the UPDATE-to-terminating claim,
+// the DELETE-by-id of successfully destroyed rows, and the force-delete of
+// leak-candidate rows older than 2 * maxAge. Everything else on the
+// InstanceStore interface panics - the purger path only touches
+// DeleteAndReturn.
+type purgerFakeStore struct {
+	mockInstanceStore
+
+	mu        sync.Mutex
+	instances map[string]*types.Instance
+}
+
+func newPurgerFakeStore(seed ...*types.Instance) *purgerFakeStore {
+	s := &purgerFakeStore{instances: make(map[string]*types.Instance)}
+	for _, inst := range seed {
+		s.instances[inst.ID] = inst
+	}
+	return s
+}
+
+func (s *purgerFakeStore) snapshot() map[string]*types.Instance {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]*types.Instance, len(s.instances))
+	for k, v := range s.instances {
+		copied := *v
+		out[k] = &copied
+	}
+	return out
+}
+
+func toInstanceState(v any) types.InstanceState {
+	switch x := v.(type) {
+	case types.InstanceState:
+		return x
+	case string:
+		return types.InstanceState(x)
+	default:
+		return ""
+	}
+}
+
+func (s *purgerFakeStore) DeleteAndReturn(_ context.Context, query string, args ...any) ([]*types.Instance, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch {
+	case strings.HasPrefix(query, "UPDATE instances SET instance_state = "):
+		// Claim path: args are [newState, poolName]. The purger passes
+		// instance_state as types.InstanceState, so accept either it or a raw string.
+		newState := toInstanceState(args[0])
+		poolName, _ := args[1].(string)
+
+		var claimed []*types.Instance
+		now := time.Now().Unix()
+		for _, inst := range s.instances {
+			if inst.Pool != poolName {
+				continue
+			}
+			inst.State = newState
+			inst.Updated = now
+			copied := *inst
+			claimed = append(claimed, &copied)
+		}
+		return claimed, nil
+
+	case strings.HasPrefix(query, "DELETE FROM instances WHERE instance_id IN "):
+		// Delete-by-id path: args are the instance IDs.
+		var deleted []*types.Instance
+		for _, a := range args {
+			id, _ := a.(string)
+			if inst, ok := s.instances[id]; ok {
+				copied := *inst
+				deleted = append(deleted, &copied)
+				delete(s.instances, id)
+			}
+		}
+		return deleted, nil
+
+	case strings.HasPrefix(query, "DELETE FROM instances WHERE (instance_pool = "):
+		// Force-delete path: args are [poolName, startedCutoff].
+		poolName, _ := args[0].(string)
+		cutoff, _ := args[1].(int64)
+
+		var deleted []*types.Instance
+		for id, inst := range s.instances {
+			if inst.Pool != poolName {
+				continue
+			}
+			if inst.Started >= cutoff {
+				continue
+			}
+			copied := *inst
+			deleted = append(deleted, &copied)
+			delete(s.instances, id)
+		}
+		return deleted, nil
+	}
+
+	return nil, errors.New("purgerFakeStore: unrecognized query: " + query)
+}
+
+// newPurgerTestManager wires a DistributedManager around the in-memory store
+// and a driver the test can configure per-scenario.
+func newPurgerTestManager(store *purgerFakeStore, driver *flexibleMockDriver, poolName string) (*DistributedManager, *poolEntry) {
+	pool := &poolEntry{
+		Pool: Pool{
+			Name:   poolName,
+			Driver: driver,
+		},
+	}
+	d := &DistributedManager{
+		Manager: Manager{
+			poolMap:       map[string]*poolEntry{poolName: pool},
+			instanceStore: store,
+			runnerName:    "test-runner",
+		},
+	}
+	return d, pool
+}
+
+func TestDistributedPurger_ExecuteInstanceCleanup_HappyPath(t *testing.T) {
+	// Dummy data: two busy rows that are well within the 2 * maxAge window
+	// so forceDeleteLeakedInstances ignores them. Destroy succeeds for all.
+	now := time.Now()
+	maxAge := 5 * time.Minute
+	store := newPurgerFakeStore(
+		&types.Instance{ID: "inst-1", Name: "vm-1", Pool: "pool1", State: types.StateInUse, Started: now.Add(-10 * time.Second).Unix()},
+		&types.Instance{ID: "inst-2", Name: "vm-2", Pool: "pool1", State: types.StateInUse, Started: now.Add(-10 * time.Second).Unix()},
+	)
+
+	var destroyed []string
+	driver := &flexibleMockDriver{
+		driverName: "mock",
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			for _, i := range instances {
+				destroyed = append(destroyed, i.ID)
+			}
+			return nil, nil
+		},
+	}
+
+	d, pool := newPurgerTestManager(store, driver, "pool1")
+	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
+
+	successful, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
+
+	assert.NoError(t, err)
+	assert.Len(t, successful, 2, "both rows should have been destroyed successfully")
+	assert.ElementsMatch(t, []string{"inst-1", "inst-2"}, destroyed, "driver.Destroy should be called for both")
+	assert.Empty(t, store.snapshot(), "store should be empty after successful destroy")
+}
+
+func TestDistributedPurger_ExecuteInstanceCleanup_DestroyFailureKeepsRow(t *testing.T) {
+	// Dummy data: three rows, driver.Destroy reports inst-2 as failed.
+	// Expectation (the fix): inst-1 and inst-3 are deleted, inst-2 stays
+	// in the DB in StateTerminating so the next purger tick retries it.
+	now := time.Now()
+	maxAge := 5 * time.Minute
+	store := newPurgerFakeStore(
+		&types.Instance{ID: "inst-1", Name: "vm-1", Pool: "pool1", State: types.StateInUse, Started: now.Add(-30 * time.Second).Unix()},
+		&types.Instance{ID: "inst-2", Name: "vm-2", Pool: "pool1", State: types.StateInUse, Started: now.Add(-30 * time.Second).Unix()},
+		&types.Instance{ID: "inst-3", Name: "vm-3", Pool: "pool1", State: types.StateInUse, Started: now.Add(-30 * time.Second).Unix()},
+	)
+
+	driver := &flexibleMockDriver{
+		driverName: "mock",
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			// Return inst-2 as failed; mirrors drivers returning a subset they couldn't destroy.
+			for _, i := range instances {
+				if i.ID == "inst-2" {
+					return []*types.Instance{i}, errors.New("simulated cloud API error for inst-2")
+				}
+			}
+			return nil, nil
+		},
+	}
+
+	d, pool := newPurgerTestManager(store, driver, "pool1")
+	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
+
+	successful, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
+	assert.NoError(t, err, "executeInstanceCleanup itself should not bubble the driver error")
+	assert.Len(t, successful, 2)
+
+	snap := store.snapshot()
+	assert.NotContains(t, snap, "inst-1", "successful row should be deleted")
+	assert.NotContains(t, snap, "inst-3", "successful row should be deleted")
+	if assert.Contains(t, snap, "inst-2", "failed row must remain for retry on the next tick") {
+		assert.Equal(t, types.StateTerminating, snap["inst-2"].State,
+			"failed row must be left in StateTerminating so stuckTerminatingCondition re-picks it")
+	}
+}
+
+func TestDistributedPurger_ForceDeleteLeakCandidateAt2xMaxAge(t *testing.T) {
+	// Dummy data:
+	//   leak: older than 2 * maxAge  -> force-deleted regardless of state
+	//   fresh: within maxAge         -> claimed & destroyed on this tick
+	//   borderline: older than maxAge but younger than 2x -> also claimed this tick
+	now := time.Now()
+	maxAge := 5 * time.Minute
+
+	store := newPurgerFakeStore(
+		&types.Instance{ID: "leak", Name: "vm-leak", Pool: "pool1", State: types.StateTerminating, Started: now.Add(-3 * maxAge).Unix()},
+		&types.Instance{ID: "fresh", Name: "vm-fresh", Pool: "pool1", State: types.StateInUse, Started: now.Add(-30 * time.Second).Unix()},
+		&types.Instance{ID: "borderline", Name: "vm-borderline", Pool: "pool1", State: types.StateInUse, Started: now.Add(-90 * time.Second).Unix()},
+	)
+
+	var sawInDestroy []string
+	driver := &flexibleMockDriver{
+		driverName: "mock",
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			for _, i := range instances {
+				sawInDestroy = append(sawInDestroy, i.ID)
+			}
+			return nil, nil
+		},
+	}
+
+	d, pool := newPurgerTestManager(store, driver, "pool1")
+	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
+
+	_, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
+	assert.NoError(t, err)
+
+	snap := store.snapshot()
+	assert.NotContains(t, snap, "leak", "row older than 2 * maxAge must be force-deleted before claim")
+	assert.NotContains(t, snap, "fresh", "successful row should be deleted")
+	assert.NotContains(t, snap, "borderline", "successful row should be deleted")
+
+	// The leak-candidate row must be removed BEFORE the claim so the driver
+	// never sees it on this tick. (It will eventually be reconciled out-of-band.)
+	assert.NotContains(t, sawInDestroy, "leak", "leak-candidate should be force-deleted before driver.Destroy is called")
+	assert.ElementsMatch(t, []string{"fresh", "borderline"}, sawInDestroy, "driver.Destroy should see only in-window rows")
+}
+
+func TestDistributedPurger_ForceDelete_NoopWhenMaxAgeZero(t *testing.T) {
+	// Safety: maxAge == 0 disables force-delete (guards against accidental
+	// whole-pool purges when the purger is misconfigured).
+	now := time.Now()
+	store := newPurgerFakeStore(
+		&types.Instance{ID: "old", Name: "vm-old", Pool: "pool1", State: types.StateInUse, Started: now.Add(-24 * time.Hour).Unix()},
+	)
+	driver := &flexibleMockDriver{driverName: "mock"}
+	d, pool := newPurgerTestManager(store, driver, "pool1")
+
+	d.forceDeleteLeakedInstances(context.Background(), pool, "busy", 0)
+
+	assert.Contains(t, store.snapshot(), "old", "maxAge=0 must be a no-op")
+}
+
+func TestDistributedPurger_StuckTerminatingRowIsRePicked(t *testing.T) {
+	// Regression for the original CI-22293 leak: a row stuck in StateTerminating
+	// from an earlier tick must be picked up again on the next tick. The real
+	// cleanupBusyInstances path relies on stuckTerminatingCondition for this;
+	// here we model a second tick by issuing the same claim and asserting the
+	// stuck row is re-claimed and destroyed successfully the second time.
+	now := time.Now()
+	maxAge := 5 * time.Minute
+	store := newPurgerFakeStore(
+		&types.Instance{ID: "stuck", Name: "vm-stuck", Pool: "pool1", State: types.StateTerminating, Started: now.Add(-30 * time.Second).Unix(), Updated: now.Add(-10 * time.Minute).Unix()},
+	)
+
+	firstCall := true
+	driver := &flexibleMockDriver{
+		driverName: "mock",
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			if firstCall {
+				firstCall = false
+				// Simulate transient failure on the first tick.
+				return instances, errors.New("transient cloud error")
+			}
+			return nil, nil
+		},
+	}
+
+	d, pool := newPurgerTestManager(store, driver, "pool1")
+	conditions := squirrel.Or{squirrel.Eq{"instance_pool": "pool1"}}
+
+	// Tick 1: Destroy fails -> row stays in terminating.
+	_, err := d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
+	assert.NoError(t, err)
+	snap := store.snapshot()
+	if assert.Contains(t, snap, "stuck") {
+		assert.Equal(t, types.StateTerminating, snap["stuck"].State)
+	}
+
+	// Tick 2: the purger re-picks the terminating row; Destroy now succeeds.
+	_, err = d.executeInstanceCleanup(context.Background(), pool, conditions, "busy", maxAge)
+	assert.NoError(t, err)
+	assert.NotContains(t, store.snapshot(), "stuck", "stuck row should be cleaned up on the retry tick")
+}

--- a/command/harness/distributed.go
+++ b/command/harness/distributed.go
@@ -228,6 +228,7 @@ func buildScalablePools(poolConfig *config.PoolFile) []jobs.ScalablePool {
 					Zones:                variant.Zones,
 					DiskSize:             variant.DiskSize,
 					DiskType:             variant.DiskType,
+					GPU:                  variant.GPU,
 				},
 			})
 		}


### PR DESCRIPTION
## Problem
`DistributedManager.executeInstanceCleanup` in `app/drivers/distributed_manager.go` deleted the instance row first (via `DELETE ... RETURNING`) and only then called `pool.Driver.Destroy`. Any non-`NotFound` driver failure (rate limit, API 5xx, network, auth) meant the row was already gone and the cloud VM was permanently orphaned — the purger would never see it again.

## Root Cause
- The purger's DELETE-then-destroy ordering is inverted relative to the correct pattern used by `cleanPool` (claim → destroy → delete-only-successful).
- Failed rows had nowhere to land: the existing `stuckTerminatingCondition` only retries rows that are *already* in `StateTerminating`, but the DELETE path bypassed that state.

GCP log `goQchiXBgr8Nn1kP6` shows instance `runner-68c55f6bcb-kznt7-linux-amd64-2yjyw7bu-q5i1t` (id `6424193904388242455`, pool `linux-amd64`) picked up by the purger at `2026-04-22T07:12:20.710Z` under `distributed_purger:busy`. The matching google driver log 107 ms later was `"google: instance not found, skipping deletion"`. There is no `destroy: instance destroyed successfully` for this id — under the old code, any transient failure here would have been a silent leak.

## Solution
- **Claim first, delete last.** `executeInstanceCleanup` now issues `UPDATE instances SET instance_state='terminating', instance_updated=now() … RETURNING …`, calls `pool.Driver.Destroy`, and only `DELETE`s rows the driver confirms destroyed.
- **Natural retries via existing loop.** Failed rows stay in `StateTerminating`; the existing `stuckTerminatingCondition` (`instance_updated < now - 2 min`) re-picks them on the next tick, so every purger run is a retry attempt.
- **Bounded safety net.** `forceDeleteLeakedInstances` runs ahead of the claim and force-deletes rows with `instance_started < now - 2 × maxAge` (using the respective `maxAgeBusy` / `maxAgeFree` the caller passes in). It emits a `Warn` with `destroy_caller=distributed_purger:leak_candidate` and logs the instance ids/names so operators can reconcile cloud-side. This keeps the table bounded when the cloud API is genuinely broken.
- **No schema change, no new store method, no change to the google driver.** Reuses `InstanceStore.DeleteAndReturn` which already executes arbitrary SQL via `QueryContext` — the `UPDATE … RETURNING instance_id, instance_name, instance_node_id, runner_name` returns the same four columns the existing scanner consumes.

## Changes Made
- `app/drivers/distributed_manager.go`:
  - `executeInstanceCleanup`: accepts `maxAge time.Duration`; claims via `UPDATE ... RETURNING`; DELETEs only successful rows; logs failed ids for visibility.
  - `forceDeleteLeakedInstances`: new helper invoked at the top of `executeInstanceCleanup` that force-deletes rows older than `2 × maxAge` and warns.
  - `cleanupBusyInstances` / `cleanupFreeInstances`: pass `maxAgeBusy` / `maxAgeFree` through.

## Testing
- [x] `go build ./...`
- [x] `go vet ./app/drivers/...`
- [x] `go test ./... -count=1` — all packages pass.
- [ ] Stage validation: watch purger logs in `prod2` for (a) `distributed_purger:busy|free` rows followed by `destroy: instance destroyed successfully` in the same pod; (b) any `instance_leak_candidate` warnings trigger a cloud-side audit.
- [ ] Verify an instance whose Destroy fails once (e.g., transient 5xx) is re-picked on the next tick and ultimately destroyed.

## Related Issues/Logs
- JIRA: https://harness.atlassian.net/browse/CI-22293
- GCP log: `goQchiXBgr8Nn1kP6` (project `cie-hosted-vm-dlite-prod`)

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*