### PR TITLE
feat: [CI-22302]: fix allow-docker firewall to check for networkconfig

### DIFF
--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -1200,7 +1200,7 @@ func (p *config) waitZoneOperation(ctx context.Context, name, zone string) error
 }
 
 func (p *config) setup(ctx context.Context) error {
-	if reflect.DeepEqual(p.tags, defaultTags) {
+	if reflect.DeepEqual(p.tags, defaultTags) && len(p.networkConfigs) == 0 {
 		return p.setupFirewall(ctx)
 	}
 	return nil


### PR DESCRIPTION
This pull request introduces a small but important change to the `setup` method in the Google driver configuration. Now, the firewall setup will only be triggered if both the tags are set to their default values and there are no network configurations present. This prevents unnecessary firewall setup when custom network configurations are specified.

* Updated the condition in the `setup` method of `driver.go` so that `setupFirewall` is only called when `tags` are default and `networkConfigs` is empty, improving configuration flexibility.
# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
