### PR TITLE
feat: [CI-22569]: Add Nomad client-level DNS configuration for Tart VMs

### DIFF
--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -321,13 +321,14 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	vmImageConfig := p.getVMImageConfig(opts)
 
 	// get the machine details where the resource job was allocated
-	ip, id, liteEngineHostPort, gitspacesPorts, err := p.fetchMachine(logr, resourceJobID)
+	ip, id, liteEngineHostPort, gitspacesPorts, nodeMeta, err := p.fetchMachine(logr, resourceJobID)
 	if err != nil {
 		defer func() {
 			go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
 		}()
 		return nil, err
 	}
+	opts.NodeMeta = nodeMeta
 
 	var gitspacesPortMappingsString string
 	gitspacesPortMappings := make(map[int]int)
@@ -533,33 +534,33 @@ func (p *config) resourceJob(cpus, memGB, machineFrequencyMhz, gitspacesPortCoun
 }
 
 // fetchMachine returns details of the machine where the job has been allocated
-func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, err error) {
+func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, nodeMeta map[string]string, err error) {
 	// Get the allocation corresponding to this job submission. If this call fails, there is not much we can do in terms
 	// of cleanup - as the job has created a virtual machine but we could not parse the node identifier.
 	l, _, err := p.client.Jobs().Allocations(id, false, nil)
 	if err != nil {
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 	if len(l) == 0 {
-		return ip, nodeID, liteEngineHostPort, ports, errors.New("scheduler: no allocation found for the job")
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, errors.New("scheduler: no allocation found for the job")
 	}
 
 	nodeID = l[0].NodeID
 	allocID := l[0].ID
 	if nodeID == "" || allocID == "" {
-		return ip, nodeID, liteEngineHostPort, ports, errors.New("scheduler: could not find an allocation identifier for the job")
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, errors.New("scheduler: could not find an allocation identifier for the job")
 	}
 
 	alloc, _, err := p.client.Allocations().Info(allocID, &api.QueryOptions{})
 	if err != nil {
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 
 	// Not expected - if nomad is unable to find a port, it should not run the job at all.
 	if alloc.Resources.Networks == nil || len(alloc.Resources.Networks) == 0 {
 		err = fmt.Errorf("scheduler: could not allocate network and ports for job")
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 
 	liteEngineHostPort = alloc.Resources.Networks[0].DynamicPorts[0].Value
@@ -571,30 +572,30 @@ func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string,
 	if liteEngineHostPort <= 0 || liteEngineHostPort > 65535 {
 		err = fmt.Errorf("scheduler: lite engine host port %d generated is not a valid port", liteEngineHostPort)
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 	for _, port := range ports {
 		if port <= 0 || port > 65535 {
 			err = fmt.Errorf("scheduler: gitspace host port %d generated is not a valid port", port)
 			logr.Errorln(err)
-			return ip, nodeID, liteEngineHostPort, ports, err
+			return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 		}
 	}
 
 	n, _, err := p.client.Nodes().Info(nodeID, &api.QueryOptions{})
 	if err != nil {
 		logr.WithError(err).Errorln("scheduler: could not get information about the node which picked up the resource job")
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 
 	ip = strings.Split(n.HTTPAddr, ":")[0]
 	if net.ParseIP(ip) == nil {
 		err = fmt.Errorf("scheduler: could not parse client machine IP: %s", ip)
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, err
+		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
 	}
 
-	return ip, nodeID, liteEngineHostPort, ports, nil
+	return ip, nodeID, liteEngineHostPort, ports, n.Meta, nil
 }
 
 // destroyJob returns a job targeted to the given node which stops and removes the VM

--- a/app/drivers/nomad/driver.go
+++ b/app/drivers/nomad/driver.go
@@ -321,14 +321,15 @@ func (p *config) Create(ctx context.Context, opts *types.InstanceCreateOpts) (*t
 	vmImageConfig := p.getVMImageConfig(opts)
 
 	// get the machine details where the resource job was allocated
-	ip, id, liteEngineHostPort, gitspacesPorts, nodeMeta, err := p.fetchMachine(logr, resourceJobID)
+	machine, err := p.fetchMachine(logr, resourceJobID)
 	if err != nil {
 		defer func() {
 			go p.deregisterJob(logr, resourceJobID, false) //nolint:errcheck
 		}()
 		return nil, err
 	}
-	opts.NodeMeta = nodeMeta
+	ip, id, liteEngineHostPort, gitspacesPorts := machine.IP, machine.NodeID, machine.LiteEngineHostPort, machine.Ports
+	opts.NodeMeta = machine.NodeMeta
 
 	var gitspacesPortMappingsString string
 	gitspacesPortMappings := make(map[int]int)
@@ -533,69 +534,79 @@ func (p *config) resourceJob(cpus, memGB, machineFrequencyMhz, gitspacesPortCoun
 	return job, id
 }
 
+type machineInfo struct {
+	IP                 string
+	NodeID             string
+	LiteEngineHostPort int
+	Ports              []int
+	NodeMeta           map[string]string
+}
+
 // fetchMachine returns details of the machine where the job has been allocated
-func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, nodeMeta map[string]string, err error) {
+func (p *config) fetchMachine(logr logger.Logger, id string) (machineInfo, error) {
+	var info machineInfo
 	// Get the allocation corresponding to this job submission. If this call fails, there is not much we can do in terms
 	// of cleanup - as the job has created a virtual machine but we could not parse the node identifier.
 	l, _, err := p.client.Jobs().Allocations(id, false, nil)
 	if err != nil {
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
 	if len(l) == 0 {
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, errors.New("scheduler: no allocation found for the job")
+		return info, errors.New("scheduler: no allocation found for the job")
 	}
 
-	nodeID = l[0].NodeID
+	info.NodeID = l[0].NodeID
 	allocID := l[0].ID
-	if nodeID == "" || allocID == "" {
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, errors.New("scheduler: could not find an allocation identifier for the job")
+	if info.NodeID == "" || allocID == "" {
+		return info, errors.New("scheduler: could not find an allocation identifier for the job")
 	}
 
 	alloc, _, err := p.client.Allocations().Info(allocID, &api.QueryOptions{})
 	if err != nil {
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
 
 	// Not expected - if nomad is unable to find a port, it should not run the job at all.
 	if alloc.Resources.Networks == nil || len(alloc.Resources.Networks) == 0 {
 		err = fmt.Errorf("scheduler: could not allocate network and ports for job")
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
 
-	liteEngineHostPort = alloc.Resources.Networks[0].DynamicPorts[0].Value
+	info.LiteEngineHostPort = alloc.Resources.Networks[0].DynamicPorts[0].Value
 	for i := 1; i < len(alloc.Resources.Networks[0].DynamicPorts); i++ {
-		ports = append(ports, alloc.Resources.Networks[0].DynamicPorts[i].Value)
+		info.Ports = append(info.Ports, alloc.Resources.Networks[0].DynamicPorts[i].Value)
 	}
 
 	// sanity check
-	if liteEngineHostPort <= 0 || liteEngineHostPort > 65535 {
-		err = fmt.Errorf("scheduler: lite engine host port %d generated is not a valid port", liteEngineHostPort)
+	if info.LiteEngineHostPort <= 0 || info.LiteEngineHostPort > 65535 {
+		err = fmt.Errorf("scheduler: lite engine host port %d generated is not a valid port", info.LiteEngineHostPort)
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
-	for _, port := range ports {
+	for _, port := range info.Ports {
 		if port <= 0 || port > 65535 {
 			err = fmt.Errorf("scheduler: gitspace host port %d generated is not a valid port", port)
 			logr.Errorln(err)
-			return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+			return info, err
 		}
 	}
 
-	n, _, err := p.client.Nodes().Info(nodeID, &api.QueryOptions{})
+	n, _, err := p.client.Nodes().Info(info.NodeID, &api.QueryOptions{})
 	if err != nil {
 		logr.WithError(err).Errorln("scheduler: could not get information about the node which picked up the resource job")
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
 
-	ip = strings.Split(n.HTTPAddr, ":")[0]
-	if net.ParseIP(ip) == nil {
-		err = fmt.Errorf("scheduler: could not parse client machine IP: %s", ip)
+	info.IP = strings.Split(n.HTTPAddr, ":")[0]
+	if net.ParseIP(info.IP) == nil {
+		err = fmt.Errorf("scheduler: could not parse client machine IP: %s", info.IP)
 		logr.Errorln(err)
-		return ip, nodeID, liteEngineHostPort, ports, nodeMeta, err
+		return info, err
 	}
 
-	return ip, nodeID, liteEngineHostPort, ports, n.Meta, nil
+	info.NodeMeta = n.Meta
+	return info, nil
 }
 
 // destroyJob returns a job targeted to the given node which stops and removes the VM

--- a/app/drivers/nomad/mac_virtualizer.go
+++ b/app/drivers/nomad/mac_virtualizer.go
@@ -3,7 +3,9 @@ package nomad
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
@@ -53,7 +55,8 @@ func (mv *MacVirtualizer) GetInitJob(vm, nodeID, userData, machinePassword, defa
 		return nil, "", "", err
 	}
 	encodedUserData := base64.StdEncoding.EncodeToString([]byte(uData))
-	startupScript := base64.StdEncoding.EncodeToString([]byte(mv.generateStartupScript(vm, machinePassword, vmImageConfig, resource, port)))
+	dnsServers := getDNSServersFromMeta(opts.NodeMeta)
+	startupScript := base64.StdEncoding.EncodeToString([]byte(mv.generateStartupScript(vm, machinePassword, vmImageConfig, resource, port, dnsServers)))
 	vmStartupScriptPath := fmt.Sprintf("/tmp/%s.sh", vm)
 	cloudInitScriptPath := fmt.Sprintf("/tmp/cloud_init_%s.sh", vm)
 	id = "tart_job_" + vm
@@ -131,10 +134,10 @@ func (mv *MacVirtualizer) generateUserData(userData string, opts *types.Instance
 	return lehelper.GenerateUserdata(userData, opts)
 }
 
-func (mv *MacVirtualizer) generateStartupScript(vmID, machinePassword string, vmImageConfig types.VMImageConfig, resource cf.NomadResource, port int) string { //nolint:gocritic
+func (mv *MacVirtualizer) generateStartupScript(vmID, machinePassword string, vmImageConfig types.VMImageConfig, resource cf.NomadResource, port int, dnsServers string) string { //nolint:gocritic
 	// can ignore the error since it was already checked
 	memGB, _ := strconv.Atoi(resource.MemoryGB)
-	return fmt.Sprintf(`
+	script := fmt.Sprintf(`
 #!/usr/bin/env bash
 set -eo pipefail
 
@@ -343,6 +346,12 @@ while true
 echo "Tart VM Started"
 `, vmImageConfig.ImageName, vmID, vmImageConfig.Username, vmImageConfig.Password, vmImageConfig.VMImageAuth.Registry,
 		vmImageConfig.VMImageAuth.Username, vmImageConfig.VMImageAuth.Password, machinePassword, resource.Cpus, convertGigsToMegs(memGB), resource.DiskSize, lockFunction, vmID, port, UnlockFunction)
+
+	if dnsServers != "" {
+		script += generateDNSSetupBlock(dnsServers)
+	}
+
+	return script
 }
 
 func (mv *MacVirtualizer) GetMachineFrequency() int {
@@ -475,4 +484,65 @@ func (mv *MacVirtualizer) GetInitJobTimeout(vmImageConfig types.VMImageConfig) t
 		return mv.nomadConfig.ByoiInitTimeout // remote image from registry
 	}
 	return mv.nomadConfig.InitTimeout // local or shorthand image
+}
+
+func getDNSServersFromMeta(meta map[string]string) string {
+	if meta == nil {
+		return ""
+	}
+	if !strings.EqualFold(meta["custom_dns"], "true") {
+		return ""
+	}
+	raw := strings.TrimSpace(meta["dns_servers"])
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, ",")
+	for _, p := range parts {
+		ip := strings.TrimSpace(p)
+		if ip == "" || net.ParseIP(ip) == nil {
+			return ""
+		}
+	}
+	return raw
+}
+
+func generateDNSSetupBlock(dnsServers string) string {
+	servers := strings.ReplaceAll(dnsServers, ",", " ")
+	return fmt.Sprintf(`
+echo "[DNS] Custom DNS configuration detected: %s"
+echo "[DNS] Applying DNS servers to VM network interface..."
+
+expect <<- DONE
+    set timeout 30
+    spawn ssh -o "ConnectTimeout=5" -o "StrictHostKeyChecking=no" "$VM_USER@$VM_IP" "networksetup -setdnsservers Ethernet %s"
+    expect {
+        "*yes/no*" { send "yes\r"; exp_continue }
+        "*Password:" { send "$VM_PASSWORD\r"; exp_continue }
+    }
+DONE
+
+if [ $? -eq 0 ]; then
+    echo "[DNS] DNS servers applied successfully"
+else
+    echo "[DNS] WARNING: Failed to apply DNS servers"
+fi
+
+echo "[DNS] Verifying DNS resolution inside VM..."
+
+expect <<- DONE
+    set timeout 15
+    spawn ssh -o "ConnectTimeout=5" -o "StrictHostKeyChecking=no" "$VM_USER@$VM_IP" "nslookup app.harness.io && nslookup github.com"
+    expect {
+        "*yes/no*" { send "yes\r"; exp_continue }
+        "*Password:" { send "$VM_PASSWORD\r"; exp_continue }
+    }
+DONE
+
+if [ $? -eq 0 ]; then
+    echo "[DNS] DNS resolution verified successfully"
+else
+    echo "[DNS] WARNING: DNS resolution check failed - proceeding anyway"
+fi
+`, dnsServers, servers)
 }

--- a/app/drivers/nomad/mac_virtualizer_test.go
+++ b/app/drivers/nomad/mac_virtualizer_test.go
@@ -1,0 +1,324 @@
+package nomad
+
+import (
+	"strings"
+	"testing"
+
+	cf "github.com/drone-runners/drone-runner-aws/command/config"
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+func TestGetDNSServersFromMeta(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     map[string]string
+		expected string
+	}{
+		{
+			name:     "nil meta returns empty",
+			meta:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty meta returns empty",
+			meta:     map[string]string{},
+			expected: "",
+		},
+		{
+			name:     "custom_dns not set returns empty",
+			meta:     map[string]string{"dns_servers": "10.200.0.16,8.8.8.8"},
+			expected: "",
+		},
+		{
+			name:     "custom_dns=false returns empty",
+			meta:     map[string]string{"custom_dns": "false", "dns_servers": "10.200.0.16,8.8.8.8"},
+			expected: "",
+		},
+		{
+			name:     "custom_dns=true with servers",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "10.200.0.16,8.8.8.8"},
+			expected: "10.200.0.16,8.8.8.8",
+		},
+		{
+			name:     "custom_dns=TRUE case insensitive",
+			meta:     map[string]string{"custom_dns": "TRUE", "dns_servers": "10.200.0.16"},
+			expected: "10.200.0.16",
+		},
+		{
+			name:     "custom_dns=True mixed case",
+			meta:     map[string]string{"custom_dns": "True", "dns_servers": "1.1.1.1,8.8.8.8"},
+			expected: "1.1.1.1,8.8.8.8",
+		},
+		{
+			name:     "custom_dns=true but dns_servers empty",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": ""},
+			expected: "",
+		},
+		{
+			name:     "custom_dns=true but dns_servers missing",
+			meta:     map[string]string{"custom_dns": "true"},
+			expected: "",
+		},
+		{
+			name:     "custom_dns=true with whitespace in dns_servers",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": " 10.200.0.16,8.8.8.8 "},
+			expected: "10.200.0.16,8.8.8.8",
+		},
+		{
+			name:     "malformed dns_servers - not an IP",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "not-an-ip"},
+			expected: "",
+		},
+		{
+			name:     "malformed dns_servers - hostname instead of IP",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "dns1.example.com"},
+			expected: "",
+		},
+		{
+			name:     "malformed dns_servers - one valid one invalid",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "10.200.0.16,bad"},
+			expected: "",
+		},
+		{
+			name:     "malformed dns_servers - double comma",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "10.200.0.16,,8.8.8.8"},
+			expected: "",
+		},
+		{
+			name:     "malformed dns_servers - trailing comma",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "10.200.0.16,"},
+			expected: "",
+		},
+		{
+			name:     "valid IPv6 address",
+			meta:     map[string]string{"custom_dns": "true", "dns_servers": "2001:4860:4860::8888,8.8.8.8"},
+			expected: "2001:4860:4860::8888,8.8.8.8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDNSServersFromMeta(tt.meta)
+			if got != tt.expected {
+				t.Errorf("getDNSServersFromMeta(%v) = %q, want %q", tt.meta, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateDNSSetupBlock(t *testing.T) {
+	tests := []struct {
+		name       string
+		dnsServers string
+		wantParts  []string
+	}{
+		{
+			name:       "single server",
+			dnsServers: "10.200.0.16",
+			wantParts: []string{
+				`[DNS] Custom DNS configuration detected: 10.200.0.16`,
+				`networksetup -setdnsservers Ethernet 10.200.0.16`,
+				`[DNS] Applying DNS servers`,
+				`[DNS] DNS servers applied successfully`,
+				`[DNS] Verifying DNS resolution`,
+				`nslookup app.harness.io`,
+				`nslookup github.com`,
+			},
+		},
+		{
+			name:       "multiple servers comma separated converts to space separated",
+			dnsServers: "10.200.0.16,8.8.8.8",
+			wantParts: []string{
+				`networksetup -setdnsservers Ethernet 10.200.0.16 8.8.8.8`,
+				`[DNS] Custom DNS configuration detected: 10.200.0.16,8.8.8.8`,
+			},
+		},
+		{
+			name:       "three servers",
+			dnsServers: "10.200.0.16,10.183.0.14,8.8.8.8",
+			wantParts: []string{
+				`networksetup -setdnsservers Ethernet 10.200.0.16 10.183.0.14 8.8.8.8`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateDNSSetupBlock(tt.dnsServers)
+			for _, part := range tt.wantParts {
+				if !strings.Contains(got, part) {
+					t.Errorf("generateDNSSetupBlock(%q) missing expected content %q", tt.dnsServers, part)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateDNSSetupBlockContainsExpectStructure(t *testing.T) {
+	block := generateDNSSetupBlock("10.200.0.16,8.8.8.8")
+
+	expectedStructures := []string{
+		"expect <<- DONE",
+		"set timeout 30",
+		"spawn ssh",
+		"StrictHostKeyChecking=no",
+		`"*Password:"`,
+	}
+
+	for _, s := range expectedStructures {
+		if !strings.Contains(block, s) {
+			t.Errorf("DNS setup block missing expected structure %q", s)
+		}
+	}
+}
+
+func TestGenerateStartupScript_WithDNS(t *testing.T) {
+	mv := &MacVirtualizer{
+		nomadConfig: &types.NomadConfig{},
+	}
+
+	vmImageConfig := types.VMImageConfig{
+		ImageName: "sonoma_14.6",
+		Username:  "admin",
+		Password:  "password",
+	}
+
+	resource := cf.NomadResource{
+		Cpus:     "4",
+		MemoryGB: "8",
+		DiskSize: "100",
+	}
+
+	script := mv.generateStartupScript("test-vm", "machinePass", vmImageConfig, resource, 9079, "10.200.0.16,8.8.8.8")
+
+	if !strings.Contains(script, "[DNS] Custom DNS configuration detected") {
+		t.Error("startup script with DNS servers should contain DNS setup block")
+	}
+	if !strings.Contains(script, "networksetup -setdnsservers Ethernet 10.200.0.16 8.8.8.8") {
+		t.Error("startup script should contain networksetup command with space-separated servers")
+	}
+	if !strings.Contains(script, "Tart VM Started") {
+		t.Error("startup script should still contain 'Tart VM Started' marker")
+	}
+}
+
+func TestGenerateStartupScript_WithoutDNS(t *testing.T) {
+	mv := &MacVirtualizer{
+		nomadConfig: &types.NomadConfig{},
+	}
+
+	vmImageConfig := types.VMImageConfig{
+		ImageName: "sonoma_14.6",
+		Username:  "admin",
+		Password:  "password",
+	}
+
+	resource := cf.NomadResource{
+		Cpus:     "4",
+		MemoryGB: "8",
+		DiskSize: "100",
+	}
+
+	script := mv.generateStartupScript("test-vm", "machinePass", vmImageConfig, resource, 9079, "")
+
+	if strings.Contains(script, "[DNS]") {
+		t.Error("startup script without DNS servers should NOT contain DNS setup block")
+	}
+	if strings.Contains(script, "networksetup -setdnsservers") {
+		t.Error("startup script without DNS servers should NOT contain networksetup command")
+	}
+	if !strings.Contains(script, "Tart VM Started") {
+		t.Error("startup script should contain 'Tart VM Started' marker")
+	}
+}
+
+func TestGenerateStartupScript_ExistingFunctionality(t *testing.T) {
+	mv := &MacVirtualizer{
+		nomadConfig: &types.NomadConfig{},
+	}
+
+	vmImageConfig := types.VMImageConfig{
+		ImageName: "sonoma_14.6",
+		Username:  "admin",
+		Password:  "password",
+		VMImageAuth: types.VMImageAuth{
+			Registry: "registry.example.com",
+			Username: "reguser",
+			Password: "regpass",
+		},
+	}
+
+	resource := cf.NomadResource{
+		Cpus:     "6",
+		MemoryGB: "12",
+		DiskSize: "390",
+	}
+
+	script := mv.generateStartupScript("vm-123", "machPass", vmImageConfig, resource, 8080, "")
+
+	expectedParts := []string{
+		`VM_IMAGE="sonoma_14.6"`,
+		`VM_ID="vm-123"`,
+		`VM_USER="admin"`,
+		`VM_PASSWORD="password"`,
+		"tart clone",
+		"tart set",
+		"--cpu 6 --memory 12288 --disk-size 390",
+		"tart run --no-graphics",
+		"tart ip",
+		"Waiting for VM to get IP",
+		"Stopping tart VM",
+		"Re-starting tart VM",
+		"Tart VM Started",
+		lockFunction[:20],
+	}
+
+	for _, part := range expectedParts {
+		if !strings.Contains(script, part) {
+			t.Errorf("startup script missing expected content: %q", part)
+		}
+	}
+}
+
+func TestIsFullyQualifiedImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected bool
+	}{
+		{
+			name:     "empty string",
+			image:    "",
+			expected: false,
+		},
+		{
+			name:     "simple image name",
+			image:    "sonoma_14.6",
+			expected: false,
+		},
+		{
+			name:     "fully qualified with registry",
+			image:    "registry.example.com/org/image:tag",
+			expected: true,
+		},
+		{
+			name:     "fully qualified with port",
+			image:    "localhost:5000/image",
+			expected: true,
+		},
+		{
+			name:     "path without registry",
+			image:    "org/image",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isFullyQualifiedImage(tt.image)
+			if got != tt.expected {
+				t.Errorf("isFullyQualifiedImage(%q) = %v, want %v", tt.image, got, tt.expected)
+			}
+		})
+	}
+}

--- a/docs/spec_nomad_client_dns.md
+++ b/docs/spec_nomad_client_dns.md
@@ -1,0 +1,233 @@
+# Spec: Nomad Client-Level DNS Configuration for Tart VMs
+
+## Problem
+
+Tart VMs use Apple's Virtualization.framework shared/NAT networking. The NAT DNS forwarder (`192.168.64.1`) returns SERVFAIL for domains where the upstream authoritative server does not set the `ra` (recursion available) flag. This breaks DNS resolution inside the VM for certain domains (e.g. `app.harness.io`), causing cloud_init to fail downloading binaries.
+
+## Solution
+
+Allow per-machine DNS configuration via Nomad client meta tags. When a Nomad client has `custom_dns=true` and `dns_servers=<comma-separated IPs>` set, the Tart VM startup script will configure those DNS servers inside the VM before cloud_init runs.
+
+## Nomad Client Configuration
+
+On machines that require custom DNS, add to the Nomad client config:
+
+```hcl
+client {
+  meta {
+    "custom_dns"  = "true"
+    "dns_servers" = "10.200.0.16,8.8.8.8"
+  }
+}
+```
+
+Machines without these meta tags are unaffected.
+
+**Note:** `dns_servers` must contain valid IPv4 or IPv6 addresses only. Hostnames (e.g. `dns1.example.com`) are not supported and will be rejected — DNS configuration will be skipped if any entry is not a valid IP.
+
+---
+
+## Code Changes
+
+### 1. `types/types.go` — Add NodeMeta to InstanceCreateOpts
+
+```go
+type InstanceCreateOpts struct {
+    // ... existing fields ...
+    TmateBinaryURI               string
+    TmateBinaryFallbackURI       string
+    NodeMeta                     map[string]string  // <-- NEW
+}
+```
+
+**Why:** Carries Nomad node metadata from `fetchMachine` to the virtualizer without changing the `Virtualizer` interface.
+
+---
+
+### 2. `app/drivers/nomad/driver.go` — Return node meta from fetchMachine
+
+**Change `fetchMachine` signature:**
+
+```go
+func (p *config) fetchMachine(logr logger.Logger, id string) (ip, nodeID string, liteEngineHostPort int, ports []int, nodeMeta map[string]string, err error)
+```
+
+**At line 584** (where `n` is already fetched), capture meta:
+
+```go
+n, _, err := p.client.Nodes().Info(nodeID, &api.QueryOptions{})
+if err != nil {
+    // ...
+}
+ip = strings.Split(n.HTTPAddr, ":")[0]
+// ...
+return ip, nodeID, liteEngineHostPort, ports, n.Meta, nil
+```
+
+**At the call site (line 324):**
+
+```go
+ip, id, liteEngineHostPort, gitspacesPorts, nodeMeta, err := p.fetchMachine(logr, resourceJobID)
+```
+
+**Before calling `GetInitJob` (after line 321):**
+
+```go
+opts.NodeMeta = nodeMeta
+```
+
+---
+
+### 3. `app/drivers/nomad/mac_virtualizer.go` — Inject DNS setup into startup script
+
+**In `GetInitJob` (line 50):**
+
+Extract DNS config from opts:
+
+```go
+dnsServers := getDNSServersFromMeta(opts.NodeMeta)
+```
+
+Pass `dnsServers` to `generateStartupScript` (add parameter).
+
+**New helper function:**
+
+```go
+func getDNSServersFromMeta(meta map[string]string) string {
+    if meta == nil {
+        return ""
+    }
+    if strings.EqualFold(meta["custom_dns"], "true") {
+        return strings.TrimSpace(meta["dns_servers"])
+    }
+    return ""
+}
+```
+
+**In `generateStartupScript`** — append DNS block after "Tart VM Started" (end of script, after SSH is verified):
+
+```go
+func (mv *MacVirtualizer) generateStartupScript(vmID, machinePassword string, vmImageConfig types.VMImageConfig, resource cf.NomadResource, port int, dnsServers string) string {
+    // ... existing script ...
+
+    script := fmt.Sprintf(`
+    ... existing content ending with ...
+    echo "Tart VM Started"
+    `, /* existing args */)
+
+    if dnsServers != "" {
+        script += mv.generateDNSSetupBlock(dnsServers, vmImageConfig.Username, vmImageConfig.Password)
+    }
+
+    return script
+}
+```
+
+**New method — `generateDNSSetupBlock`:**
+
+```go
+func (mv *MacVirtualizer) generateDNSSetupBlock(dnsServers, vmUser, vmPassword string) string {
+    // Convert "10.200.0.16,8.8.8.8" to "10.200.0.16 8.8.8.8" (space-separated for networksetup)
+    servers := strings.ReplaceAll(dnsServers, ",", " ")
+
+    return fmt.Sprintf(`
+echo "[DNS] Custom DNS configuration detected: %s"
+echo "[DNS] Applying DNS servers to VM network interface..."
+
+expect <<- DONE
+    set timeout 30
+    spawn ssh -o "ConnectTimeout=5" -o "StrictHostKeyChecking=no" "$VM_USER@$VM_IP" "networksetup -setdnsservers Ethernet %s"
+    expect {
+        "*yes/no*" { send "yes\r"; exp_continue }
+        "*Password:" { send "$VM_PASSWORD\r"; exp_continue }
+    }
+DONE
+
+if [ $? -eq 0 ]; then
+    echo "[DNS] DNS servers applied successfully"
+else
+    echo "[DNS] WARNING: Failed to apply DNS servers"
+fi
+
+echo "[DNS] Verifying DNS resolution inside VM..."
+
+expect <<- DONE
+    set timeout 15
+    spawn ssh -o "ConnectTimeout=5" -o "StrictHostKeyChecking=no" "$VM_USER@$VM_IP" "nslookup app.harness.io && nslookup github.com"
+    expect {
+        "*yes/no*" { send "yes\r"; exp_continue }
+        "*Password:" { send "$VM_PASSWORD\r"; exp_continue }
+    }
+DONE
+
+if [ $? -eq 0 ]; then
+    echo "[DNS] DNS resolution verified successfully"
+else
+    echo "[DNS] WARNING: DNS resolution check failed - proceeding anyway"
+fi
+`, dnsServers, servers)
+}
+```
+
+---
+
+### 4. `app/drivers/nomad/linux_virtualizer.go` — No changes
+
+Linux virtualizer receives `opts.NodeMeta` but ignores it. No code change needed.
+
+---
+
+## Execution Flow
+
+```
+1. Runner calls fetchMachine()
+   └── Fetches Nomad node info including n.Meta
+   └── Returns nodeMeta map to caller
+
+2. Runner sets opts.NodeMeta = nodeMeta
+
+3. Runner calls GetInitJob(... opts ...)
+   └── MacVirtualizer reads opts.NodeMeta
+   └── getDNSServersFromMeta() returns "10.200.0.16,8.8.8.8" or ""
+
+4. generateStartupScript() builds bash script:
+   └── [existing] Clone VM, start VM, port forward, restart VM, verify SSH
+   └── [existing] echo "Tart VM Started"
+   └── [NEW - conditional] DNS setup block (only if dnsServers != "")
+       ├── SSH into VM: networksetup -setdnsservers Ethernet 10.200.0.16 8.8.8.8
+       ├── Log success/failure
+       └── Verify: nslookup app.harness.io && nslookup github.com
+
+5. run_cmd task executes cloud_init (downloads binaries, starts lite-engine)
+   └── DNS is already configured, wget/curl resolve correctly
+```
+
+---
+
+## Behavior Matrix
+
+| Nomad Client Meta | Behavior |
+|---|---|
+| No `custom_dns` tag | No DNS block emitted, script unchanged |
+| `custom_dns=true`, `dns_servers` set | DNS applied, logged, verified |
+| `custom_dns=true`, `dns_servers` empty | Warning logged, no DNS change applied |
+| `custom_dns=false` or missing | No DNS block emitted |
+| DNS applied but resolution fails | Warning logged, script continues (non-blocking) |
+
+---
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `types/types.go` | Add `NodeMeta map[string]string` to `InstanceCreateOpts` |
+| `app/drivers/nomad/driver.go` | Update `fetchMachine` return signature; populate `opts.NodeMeta` |
+| `app/drivers/nomad/mac_virtualizer.go` | Add `dnsServers` param to `generateStartupScript`; add `getDNSServersFromMeta()` and `generateDNSSetupBlock()` |
+
+---
+
+## Rollout
+
+1. Deploy code change to drone-runner-aws
+2. On target Nomad clients, add meta tags to client config and restart Nomad agent
+3. Machines without meta tags are unaffected (no meta = no DNS block)

--- a/types/types.go
+++ b/types/types.go
@@ -199,6 +199,7 @@ type InstanceCreateOpts struct {
 	EnvmanBinaryFallbackURI      string
 	TmateBinaryURI               string
 	TmateBinaryFallbackURI       string
+	NodeMeta                     map[string]string
 }
 
 // Platform defines the target platform.


### PR DESCRIPTION
## Summary
- Adds support for per-machine DNS configuration via Nomad client meta tags (`custom_dns`, `dns_servers`)
- When configured, DNS servers are set inside the Tart VM after startup but before cloud_init runs, fixing resolution failures caused by Apple's NAT DNS forwarder
- Includes IP validation (IPv4/IPv6 only, hostnames rejected) and non-blocking DNS verification

## Changes
- `types/types.go` — Added `NodeMeta` field to `InstanceCreateOpts`
- `app/drivers/nomad/driver.go` — Updated `fetchMachine` to return node meta from Nomad API
- `app/drivers/nomad/mac_virtualizer.go` — Conditionally injects DNS setup block into startup script
- `app/drivers/nomad/mac_virtualizer_test.go` — Unit tests covering new and existing functionality
- `docs/spec_nomad_client_dns.md` — Design spec

## Nomad Client Configuration
```hcl
client {
  meta {
    "custom_dns"  = "true"
    "dns_servers" = "10.200.0.16,8.8.8.8"
  }
}
```

## Test plan
- [x] Unit tests pass (24 cases covering validation, script generation, regression)
- [ ] Deploy to target Nomad clients with meta tags and verify DNS applied in VM logs
- [ ] Verify non-configured machines are unaffected (no DNS block emitted)
- [ ] Verify malformed dns_servers config is rejected gracefully