### PR TITLE
feat: [CI-22316]: Add instance source (pool/predictor/ondemand) as a VM label for hosted instances

### DIFF
--- a/app/drivers/provisioner.go
+++ b/app/drivers/provisioner.go
@@ -268,9 +268,11 @@ func (m *Manager) setupInstance(
 		retain = "true"
 	}
 	createOptions.InternalLabels = map[string]string{"retain": retain}
+	source := resolveInstanceSource(setupParams)
 	if createOptions.IsHosted {
 		createOptions.VMLabels = map[string]string{
 			"pool_id": pool.Name,
+			"source":  string(source),
 		}
 		if m.env != "" {
 			createOptions.VMLabels["harness_env"] = m.env
@@ -326,7 +328,7 @@ func (m *Manager) setupInstance(
 		inst.VariantID = defaultVariantID
 	}
 
-	inst.Source = resolveInstanceSource(setupParams)
+	inst.Source = source
 
 	if inst.Labels == nil {
 		labelsBytes, marshalErr := json.Marshal(map[string]string{"retain": "false"})


### PR DESCRIPTION
# Description
Add instance source (pool/predictor/ondemand) as a VM label for hosted instances

# Goal
Include the instance source as a VM label alongside pool_id and harness_env when the instance is hosted, so the label is visible directly on the GCP instance (UI, billing exports, log labels, etc.) without a DB lookup.

# Tested via
- [x] `source` is added in the **labels**
- [x] `harness_env` and `pool_id` were consistent


## Before
<img width="2181" height="1185" alt="image" src="https://github.com/user-attachments/assets/1b947b06-7255-4351-b831-81c0fc631e05" />

## After
<img width="2177" height="1175" alt="image" src="https://github.com/user-attachments/assets/5be55d8c-fa6e-47af-b7e9-fbf758d9616e" />
