### PR TITLE
feat: [CI-22735]: Add docker connector support for BYOI

### DIFF
--- a/app/drivers/nomad/mac_virtualizer.go
+++ b/app/drivers/nomad/mac_virtualizer.go
@@ -154,83 +154,71 @@ tart_list=$(/opt/homebrew/bin/tart list | awk 'NR>1 {print $2}')
 # Function to check if an image name is fully qualified
 is_fully_qualified_image() {
   local image_name="$1"
-  
-  # Check if image name contains a slash
   if [[ "$image_name" != *"/"* ]]; then
-    return 1  # Not fully qualified
+    return 1
   fi
-  
-  # Extract the registry part (before the first slash)
-  local registry_part=${image_name%%/*}
-  
-  # Check if registry part contains a dot or colon
+  local registry_part="${image_name%%%%/*}"
   if [[ "$registry_part" == *"."* || "$registry_part" == *":"* ]]; then
-    return 0  # Is fully qualified
-  else
-    return 1  # Not fully qualified
+    return 0
   fi
+  return 1
 }
 
-# Function to encode the image name
-encode() {
-  echo -n "ENC:$(echo -n "$1" | base64)"
-}
-
-# Only sanitize if VM_IMAGE is fully qualified
+# Normalize a fully qualified image with no :tag and no @digest to :latest,
+# matching how tart stores it in 'tart list' output. This ensures the cache
+# presence check below works for inputs like "registry/foo" (no tag).
 if is_fully_qualified_image "$VM_IMAGE"; then
-  ENCODED_IMAGE_NAME=$(encode "$VM_IMAGE")
-else
-  ENCODED_IMAGE_NAME="$VM_IMAGE"
+  vm_image_last_segment="${VM_IMAGE##*/}"
+  if [[ "$vm_image_last_segment" != *":"* && "$VM_IMAGE" != *"@"* ]]; then
+    VM_IMAGE="${VM_IMAGE}:latest"
+  fi
 fi
 
-# Check if the image is already in the tart list
-if echo "$tart_list" | grep -q "$ENCODED_IMAGE_NAME"; then
-  echo "Image '$ENCODED_IMAGE_NAME' is already present. Nothing to do."
-else
-  echo "Image '$ENCODED_IMAGE_NAME' not found."
-  
-  # Check if the image name is fully qualified
-  if is_fully_qualified_image "$VM_IMAGE"; then
-    echo "Fully qualified image detected. Deleting all fully qualified images..."
-    
-    # Loop through each image and delete only fully qualified images
-    for image in $tart_list; do
-      if is_fully_qualified_image "$image" || [[ "$image" == ENC:* ]]; then
-        echo "Deleting fully qualified image '$image'..."
+# For fully qualified images: ensure the image is pulled and clean up other
+# fully qualified images to free disk space. Non-fully-qualified images are
+# left untouched and used as-is.
+#
+# Note on the two-refs case: a single 'tart pull foo:tag' creates both
+# 'foo:tag' and 'foo@sha256:...' in the cache. When the same image is
+# requested again, the presence check below skips the entire cleanup+pull
+# block, so both refs survive. When a different image is requested, both old
+# refs are deleted by the loop (each is != VM_IMAGE).
+if is_fully_qualified_image "$VM_IMAGE"; then
+  if echo "$tart_list" | grep -qxF "$VM_IMAGE"; then
+    echo "Image '$VM_IMAGE' is already present. Skipping pull."
+  else
+    echo "Image '$VM_IMAGE' not found. Cleaning up other fully qualified images..."
+    while IFS= read -r image; do
+      [ -z "$image" ] && continue
+      if is_fully_qualified_image "$image" && [[ "$image" != "$VM_IMAGE" ]]; then
+        echo "Deleting old image '$image'..."
         /opt/homebrew/bin/tart delete "$image" || true
-      else
-        echo "Skipping non-fully qualified image '$image'..."
       fi
-    done
-    
-    echo "Done deleting fully qualified images."
-  else
-    echo "Non-fully qualified image. Skipping deletion of other images."
-  fi
+    done <<< "$tart_list"
 
-  if [ -n "$REGISTRY" ] && [ -n "$REGISTRY_USERNAME" ] && [ -n "$REGISTRY_PASSWORD" ]; then
-	  echo "Pulling image $VM_IMAGE..."
-	  TART_REGISTRY_HOSTNAME="$REGISTRY" TART_REGISTRY_USERNAME="$REGISTRY_USERNAME" TART_REGISTRY_PASSWORD="$REGISTRY_PASSWORD" /opt/homebrew/bin/tart pull "$VM_IMAGE"
+    if [ -n "$REGISTRY" ]; then
+      echo "Pulling image $VM_IMAGE from registry $REGISTRY..."
+      export TART_REGISTRY_HOSTNAME="$REGISTRY"
+      if [ -n "$REGISTRY_USERNAME" ]; then
+        export TART_REGISTRY_USERNAME="$REGISTRY_USERNAME"
+      fi
+      if [ -n "$REGISTRY_PASSWORD" ]; then
+        export TART_REGISTRY_PASSWORD="$REGISTRY_PASSWORD"
+      fi
 
-      echo "Exporting image $VM_IMAGE to /tmp/${ENCODED_IMAGE_NAME}.tvm..."
-      /opt/homebrew/bin/tart export "$VM_IMAGE" "/tmp/${ENCODED_IMAGE_NAME}.tvm"
+      /opt/homebrew/bin/tart pull "$VM_IMAGE"
 
-	  echo "Pruning tart OCI cache..."
-	  /opt/homebrew/bin/tart prune --entries caches --older-than=0
-
-      echo "Importing image from /tmp/${ENCODED_IMAGE_NAME}.tvm as $ENCODED_IMAGE_NAME..."
-      /opt/homebrew/bin/tart import "/tmp/${ENCODED_IMAGE_NAME}.tvm" "$ENCODED_IMAGE_NAME"
-
-      echo "Removing temporary file /tmp/${ENCODED_IMAGE_NAME}.tvm..."
-      rm -f "/tmp/${ENCODED_IMAGE_NAME}.tvm" || true
-  else
-	  echo "No registry details provided, skipping logging."
+      unset TART_REGISTRY_HOSTNAME TART_REGISTRY_USERNAME TART_REGISTRY_PASSWORD
+      echo "Pulled image $VM_IMAGE."
+    else
+      echo "No registry provided, skipping pull."
+    fi
   fi
 fi
 
 echo "Cloning tart VM with id $VM_ID"
 # Install the VM
-/opt/homebrew/bin/tart clone "$ENCODED_IMAGE_NAME" "$VM_ID"
+/opt/homebrew/bin/tart clone "$VM_IMAGE" "$VM_ID"
 
 echo "Setting tart VM config with id $VM_ID"
 # Update VM configuration

--- a/app/drivers/nomad/mac_virtualizer_script_test.go
+++ b/app/drivers/nomad/mac_virtualizer_script_test.go
@@ -1,6 +1,7 @@
 package nomad
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,7 +20,7 @@ import (
 func TestGenerateStartupScriptSyntax(t *testing.T) {
 	script := generateScriptForTest(t, "ghcr.io/example/macos-base:latest", "ghcr.io")
 
-	cmd := exec.Command("bash", "-n")
+	cmd := exec.CommandContext(context.Background(), "bash", "-n")
 	cmd.Stdin = strings.NewReader(script)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -151,10 +152,11 @@ func TestImageCleanup(t *testing.T) {
 			dir := t.TempDir()
 			mockPath := installMockTart(t, dir, tc.tartList)
 			script := extractImageCleanupScript(t, tc.vmImage, tc.registry)
-			// Redirect the hard-coded /opt/homebrew/bin/tart path to our mock.
-			script = strings.ReplaceAll(script, "/opt/homebrew/bin/tart", mockPath)
+			// Redirect the hard-coded /opt/homebrew/bin/tart path to our mock,
+			// invoked via `bash <mockPath>` so we don't need the executable bit.
+			script = strings.ReplaceAll(script, "/opt/homebrew/bin/tart", "bash "+mockPath)
 
-			cmd := exec.Command("bash")
+			cmd := exec.CommandContext(context.Background(), "bash")
 			cmd.Stdin = strings.NewReader(script)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
@@ -217,7 +219,7 @@ func installMockTart(t *testing.T, dir string, tartList []string) string {
 	for _, img := range tartList {
 		rows = append(rows, "OCI "+img+" 0 0 0 stopped")
 	}
-	if err := os.WriteFile(listFile, []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(listFile, []byte(strings.Join(rows, "\n")+"\n"), 0o600); err != nil {
 		t.Fatalf("write list file: %v", err)
 	}
 	callsFile := filepath.Join(dir, "calls.log")
@@ -229,9 +231,11 @@ func installMockTart(t *testing.T, dir string, tartList []string) string {
 		"esac\n" +
 		"exit 0\n"
 	mockPath := filepath.Join(dir, "tart")
-	if err := os.WriteFile(mockPath, []byte(mock), 0o755); err != nil {
+	if err := os.WriteFile(mockPath, []byte(mock), 0o600); err != nil {
 		t.Fatalf("write mock tart: %v", err)
 	}
+	// The mock is invoked as `bash <mockPath> ...` from the test script, so we
+	// don't need the executable bit (and gosec G302/G306 forbid setting it).
 	return mockPath
 }
 

--- a/app/drivers/nomad/mac_virtualizer_script_test.go
+++ b/app/drivers/nomad/mac_virtualizer_script_test.go
@@ -93,10 +93,10 @@ func TestImageCleanup(t *testing.T) {
 			},
 		},
 		{
-			name:     "empty cache just pulls the requested image",
-			vmImage:  "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
-			registry: "registry-1.docker.io",
-			tartList: nil,
+			name:            "empty cache just pulls the requested image",
+			vmImage:         "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			registry:        "registry-1.docker.io",
+			tartList:        nil,
 			expectedDeletes: nil,
 			expectedPulls: []string{
 				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
@@ -125,10 +125,10 @@ func TestImageCleanup(t *testing.T) {
 			expectedPulls:   nil,
 		},
 		{
-			name:     "image without tag against empty cache pulls normalized :latest",
-			vmImage:  "ghcr.io/example/macos-base",
-			registry: "ghcr.io",
-			tartList: nil,
+			name:            "image without tag against empty cache pulls normalized :latest",
+			vmImage:         "ghcr.io/example/macos-base",
+			registry:        "ghcr.io",
+			tartList:        nil,
 			expectedDeletes: nil,
 			expectedPulls: []string{
 				"ghcr.io/example/macos-base:latest",

--- a/app/drivers/nomad/mac_virtualizer_script_test.go
+++ b/app/drivers/nomad/mac_virtualizer_script_test.go
@@ -1,0 +1,270 @@
+package nomad
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	cf "github.com/drone-runners/drone-runner-aws/command/config"
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+// TestGenerateStartupScriptSyntax catches regressions where Go fmt-string
+// escaping breaks the generated bash (e.g. unescaped `%` in parameter
+// expansions producing `%!:(MISSING)` and an unbalanced `(`).
+func TestGenerateStartupScriptSyntax(t *testing.T) {
+	script := generateScriptForTest(t, "ghcr.io/example/macos-base:latest", "ghcr.io")
+
+	cmd := exec.Command("bash", "-n")
+	cmd.Stdin = strings.NewReader(script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash syntax check failed: %v\noutput: %s\n--- script ---\n%s", err, out, script)
+	}
+}
+
+// TestImageCleanup exercises the tart image cleanup + pull logic with a mock
+// `tart` binary, verifying which images get deleted and pulled in each case.
+func TestImageCleanup(t *testing.T) {
+	cases := []struct {
+		name            string
+		vmImage         string
+		registry        string
+		tartList        []string
+		expectedDeletes []string
+		expectedPulls   []string
+	}{
+		{
+			name:     "different fully qualified tag deletes both old refs and pulls new",
+			vmImage:  "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			registry: "registry-1.docker.io",
+			tartList: []string{
+				"sequoia_local_a",
+				"sonoma_local_b",
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.5",
+				"registry-1.docker.io/harness/macos-vm-images@sha256:abc",
+			},
+			expectedDeletes: []string{
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.5",
+				"registry-1.docker.io/harness/macos-vm-images@sha256:abc",
+			},
+			expectedPulls: []string{
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			},
+		},
+		{
+			name:     "same tag already present preserves both refs and skips pull",
+			vmImage:  "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			registry: "registry-1.docker.io",
+			tartList: []string{
+				"sequoia_local_a",
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+				"registry-1.docker.io/harness/macos-vm-images@sha256:abc",
+			},
+			expectedDeletes: nil,
+			expectedPulls:   nil,
+		},
+		{
+			name:     "non fully qualified image request skips cleanup and pull entirely",
+			vmImage:  "sequoia_local_a",
+			registry: "",
+			tartList: []string{
+				"sequoia_local_a",
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.5",
+			},
+			expectedDeletes: nil,
+			expectedPulls:   nil,
+		},
+		{
+			name:     "non fully qualified images in cache are never deleted",
+			vmImage:  "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			registry: "registry-1.docker.io",
+			tartList: []string{
+				"sequoia_local_a",
+				"sonoma_local_b",
+			},
+			expectedDeletes: nil,
+			expectedPulls: []string{
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			},
+		},
+		{
+			name:     "empty cache just pulls the requested image",
+			vmImage:  "registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			registry: "registry-1.docker.io",
+			tartList: nil,
+			expectedDeletes: nil,
+			expectedPulls: []string{
+				"registry-1.docker.io/harness/macos-vm-images:vanilla_sequoia_15.6",
+			},
+		},
+		{
+			name:     "image without tag is normalized to :latest and matches cached :latest",
+			vmImage:  "ghcr.io/example/macos-base",
+			registry: "ghcr.io",
+			tartList: []string{
+				"ghcr.io/example/macos-base:latest",
+				"ghcr.io/example/macos-base@sha256:abc",
+			},
+			expectedDeletes: nil,
+			expectedPulls:   nil,
+		},
+		{
+			name:     "image with explicit :latest matches cached :latest",
+			vmImage:  "ghcr.io/example/macos-base:latest",
+			registry: "ghcr.io",
+			tartList: []string{
+				"ghcr.io/example/macos-base:latest",
+				"ghcr.io/example/macos-base@sha256:abc",
+			},
+			expectedDeletes: nil,
+			expectedPulls:   nil,
+		},
+		{
+			name:     "image without tag against empty cache pulls normalized :latest",
+			vmImage:  "ghcr.io/example/macos-base",
+			registry: "ghcr.io",
+			tartList: nil,
+			expectedDeletes: nil,
+			expectedPulls: []string{
+				"ghcr.io/example/macos-base:latest",
+			},
+		},
+		{
+			name:     "registry with port and no tag is normalized correctly",
+			vmImage:  "registry.local:5000/team/macos-base",
+			registry: "registry.local:5000",
+			tartList: []string{
+				"registry.local:5000/team/macos-base:latest",
+			},
+			expectedDeletes: nil,
+			expectedPulls:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mockPath := installMockTart(t, dir, tc.tartList)
+			script := extractImageCleanupScript(t, tc.vmImage, tc.registry)
+			// Redirect the hard-coded /opt/homebrew/bin/tart path to our mock.
+			script = strings.ReplaceAll(script, "/opt/homebrew/bin/tart", mockPath)
+
+			cmd := exec.Command("bash")
+			cmd.Stdin = strings.NewReader(script)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("script failed: %v\noutput:\n%s", err, out)
+			}
+
+			deletes, pulls := readMockCalls(t, dir)
+			if !sortedEqual(deletes, tc.expectedDeletes) {
+				t.Errorf("deletes mismatch\n  got:  %v\n  want: %v\nscript output:\n%s",
+					deletes, tc.expectedDeletes, out)
+			}
+			if !sortedEqual(pulls, tc.expectedPulls) {
+				t.Errorf("pulls mismatch\n  got:  %v\n  want: %v\nscript output:\n%s",
+					pulls, tc.expectedPulls, out)
+			}
+		})
+	}
+}
+
+// generateScriptForTest invokes generateStartupScript with stable test values.
+func generateScriptForTest(t *testing.T, vmImage, registry string) string {
+	t.Helper()
+	mv := NewMacVirtualizer(&types.NomadConfig{})
+	imgCfg := types.VMImageConfig{
+		ImageName: vmImage,
+		Username:  "admin",
+		Password:  "pw",
+		VMImageAuth: types.VMImageAuth{
+			Registry: registry,
+			Username: "u",
+			Password: "p",
+		},
+	}
+	resource := cf.NomadResource{Cpus: "4", MemoryGB: "8", DiskSize: "100"}
+	return mv.generateStartupScript("vm-id", "machine-pw", imgCfg, resource, 8080)
+}
+
+// extractImageCleanupScript returns the portion of the generated startup
+// script up to (but not including) the `tart clone` step. This lets tests
+// exercise just the image presence-check, cleanup and pull logic without
+// trying to actually start a VM.
+func extractImageCleanupScript(t *testing.T, vmImage, registry string) string {
+	t.Helper()
+	full := generateScriptForTest(t, vmImage, registry)
+	marker := `echo "Cloning tart VM`
+	cutAt := strings.Index(full, marker)
+	if cutAt < 0 {
+		t.Fatalf("could not find %q in generated script", marker)
+	}
+	return full[:cutAt]
+}
+
+// installMockTart writes a fake `tart` shell script into dir that responds
+// to `tart list` with the given image names (in the same column layout as
+// real tart output) and logs every invocation's args to calls.log.
+func installMockTart(t *testing.T, dir string, tartList []string) string {
+	t.Helper()
+	listFile := filepath.Join(dir, "list.txt")
+	rows := []string{"Source Name Disk Size SizeOnDisk State"}
+	for _, img := range tartList {
+		rows = append(rows, "OCI "+img+" 0 0 0 stopped")
+	}
+	if err := os.WriteFile(listFile, []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write list file: %v", err)
+	}
+	callsFile := filepath.Join(dir, "calls.log")
+
+	mock := "#!/bin/bash\n" +
+		"echo \"$@\" >> '" + callsFile + "'\n" +
+		"case \"$1\" in\n" +
+		"  list) cat '" + listFile + "' ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	mockPath := filepath.Join(dir, "tart")
+	if err := os.WriteFile(mockPath, []byte(mock), 0o755); err != nil {
+		t.Fatalf("write mock tart: %v", err)
+	}
+	return mockPath
+}
+
+// readMockCalls parses the mock tart call log and returns the image names
+// passed to `tart delete` and `tart pull`.
+func readMockCalls(t *testing.T, dir string) (deletes, pulls []string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "calls.log"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		t.Fatalf("read calls log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "delete":
+			deletes = append(deletes, fields[1])
+		case "pull":
+			pulls = append(pulls, fields[1])
+		}
+	}
+	return deletes, pulls
+}
+
+func sortedEqual(a, b []string) bool {
+	x := append([]string(nil), a...)
+	y := append([]string(nil), b...)
+	sort.Strings(x)
+	sort.Strings(y)
+	return reflect.DeepEqual(x, y)
+}

--- a/command/harness/logutil.go
+++ b/command/harness/logutil.go
@@ -71,15 +71,32 @@ func usePlainFormatter(l *logrus.Logger) { l.SetFormatter(&plainFormatter{}) }
 
 // logRequestedMachine prints the standard "Requested machine" block with
 // size, OS, Arch, image, and nested virtualization flag.
-func logRequestedMachine(logr *logrus.Entry, poolManager drivers.IManager, poolID string, platform *types.Platform, resourceClass, imageVersion, stageRuntimeID string, isNested bool) {
+//
+// The image shown follows this priority:
+//  1. imageVersion (from VMImageConfig.ImageVersion)
+//  2. imageName    (from VMImageConfig.ImageName)
+//  3. pool image   (derived from the pool YAML config)
+func logRequestedMachine(logr *logrus.Entry, poolManager drivers.IManager, poolID string, platform *types.Platform, resourceClass, imageVersion, imageName, stageRuntimeID string, isNested bool) {
 	printTitle(logr, "Requested machine:")
 	printKV(logr, "Machine Size", resourceClass)
 	printKV(logr, "OS", capitalize(platform.OS))
 	printKV(logr, "Arch", capitalize(platform.Arch))
-	poolImageForLog := derivePoolImageForLog(poolManager, poolID)
-	printKV(logr, "Image Version", useNonEmpty(imageVersion, poolImageForLog))
+	printKV(logr, "Image Version", resolveImageForLog(poolManager, poolID, imageVersion, imageName))
 	printKV(logr, "Hardware Acceleration (Nested Virtualization)", isNested)
 	printKV(logr, "Stage Runtime ID", stageRuntimeID)
+}
+
+// resolveImageForLog picks the image identifier to log, preferring the
+// explicit imageVersion, then imageName, then the pool's configured image
+// (with its last path segment extracted for readability).
+func resolveImageForLog(poolManager drivers.IManager, poolID, imageVersion, imageName string) string {
+	if imageVersion != "" {
+		return imageVersion
+	}
+	if imageName != "" {
+		return imageName
+	}
+	return lastPathSegment(derivePoolImageForLog(poolManager, poolID))
 }
 
 // derivePoolImageForLog extracts an image identifier from the pool YAML config for logging purposes.

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -172,7 +172,7 @@ func HandleSetup(
 		WithField("arch", platform.Arch)
 
 	logRequestedMachine(logr, poolManager, fetchPool(r.SetupRequest.LogConfig.AccountID, r.PoolID, poolMapByAccount),
-		&platform, r.ResourceClass, r.VMImageConfig.ImageVersion, stageRuntimeID, r.NestedVirtualization)
+		&platform, r.ResourceClass, r.VMImageConfig.ImageVersion, r.VMImageConfig.ImageName, stageRuntimeID, r.NestedVirtualization)
 
 	// try to provision an instance with fallbacks
 	setupTime := time.Duration(0)


### PR DESCRIPTION
## Problem
For BYOI macOS VM images we only supported the GCP Artifact Registry path: the tart-based pull flow assumed `REGISTRY`, `REGISTRY_USERNAME`, and `REGISTRY_PASSWORD` would all be set, base64-encoded the image name (`ENC:<b64>`) to work around fully-qualified-name handling, and skipped the pull entirely when credentials were missing. As a result, generic docker registries (Docker Hub, GHCR, self-hosted, etc.) couldn't be used as BYOI sources.

## Root Cause
- `mac_virtualizer.go` hard-coded a GCP-style flow: it required all three registry env vars to attempt a pull, and used a custom `ENC:` base64 scheme for image names which forced an extra `tart export → tart import` step.
- The cache presence check used a substring `grep` against `tart list`, which doesn't match cleanly against tart's `repo:tag` / `repo@sha256:...` cache entries.
- Image names without an explicit `:tag` weren't normalized, so `tart pull foo/bar` wouldn't match the `foo/bar:latest` entry that tart actually stores.
- The "Requested machine" log only displayed `ImageVersion`, never `ImageName`, so BYOI users couldn't easily see which image got pulled.

## Solution
Generalize the BYOI image pull path so any docker connector works:

1. **Registry creds optional** — only `REGISTRY` is required. `REGISTRY_USERNAME` / `REGISTRY_PASSWORD` are exported only when set, enabling anonymous pulls from public registries.
2. **Drop the `ENC:` base64 workaround** — pass the original image name through to `tart pull`/`tart clone` directly. No more export/import round-trip.
3. **Normalize tag-less fully-qualified images to `:latest`** so the cache presence check (`grep -qxF`) matches `tart list` output.
4. **Robust cleanup of stale BYOI images** — iterate `tart list` line by line, deleting only fully-qualified images that aren't the current `VM_IMAGE`. Two-refs case (`foo:tag` + `foo@sha256:...`) is handled correctly: same-image requests preserve both refs, different-image requests delete both.
5. **Log image identity** — `logRequestedMachine` now falls back to `VMImageConfig.ImageName` when `ImageVersion` is empty so the "Image Version" line in the build log reflects the BYOI image actually requested.

## Changes Made
- `app/drivers/nomad/mac_virtualizer.go` — rewritten startup-script image cleanup/pull section (no `ENC:` encoding, optional credentials, tag normalization, line-safe cleanup loop).
- `app/drivers/nomad/mac_virtualizer_script_test.go` *(new)* — table-driven tests:
  - bash syntax check on the generated script.
  - 9 image-cleanup scenarios driven by a mock `tart` binary (different-tag deletes both old refs; same-tag preserves both refs; non-FQ inputs skip everything; empty cache; tag-less normalization for `:latest`; registry-with-port).
- `command/harness/logutil.go` — added `resolveImageForLog` and threaded `imageName` through `logRequestedMachine`.
- `command/harness/setup.go` — passes `r.VMImageConfig.ImageName` to `logRequestedMachine`.

## Testing
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass, including the new `mac_virtualizer_script_test.go` cases
- [ ] Smoke test on a Mac runner with a non-GCP docker connector (Docker Hub / GHCR) once merged

## Related Issues/Logs
- JIRA: https://harness.atlassian.net/browse/CI-22735

🤖 Generated with [Claude Code](https://claude.com/claude-code)