### PR TITLE
fix: [CI-22843]: set CreatedAt on hotpool capacity reservations

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -417,6 +417,7 @@ func (d *DistributedManager) provisionFromPool(
 			capacity = &types.CapacityReservation{
 				InstanceID: inst.ID,
 				PoolName:   poolName,
+				CreatedAt:  time.Now().Unix(),
 			}
 			return inst, capacity, true, candidateVariantID, nil
 		}

--- a/store/database/sql/capacity_reservation.go
+++ b/store/database/sql/capacity_reservation.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/drone-runners/drone-runner-aws/store"
 	"github.com/drone-runners/drone-runner-aws/types"
@@ -28,6 +29,9 @@ func (s CapacityReservationStore) Find(_ context.Context, id string) (*types.Cap
 }
 
 func (s CapacityReservationStore) Create(_ context.Context, capacityReservation *types.CapacityReservation) error {
+	if capacityReservation.CreatedAt == 0 {
+		capacityReservation.CreatedAt = time.Now().Unix()
+	}
 	query, arg, err := s.db.BindNamed(capacityReservationInsert, capacityReservation)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- `DistributedManager.provisionFromPool` hotpool/predictor claim built a `CapacityReservation` literal without `CreatedAt`, so the row was inserted with `created_at = 0` and the purger reaped it seconds after creation (taking the predictor VM with it). Setup then fell through to on-demand creation and could fail on stockouts. Set `CreatedAt: time.Now().Unix()` on the literal in `app/drivers/distributed_manager.go:417`.
- Added a defense-in-depth guard in `store/database/sql/capacity_reservation.go` `Create`: default `CreatedAt` to `time.Now().Unix()` when zero, so any future literal that misses it is still safe.

JIRA: https://harness.atlassian.net/browse/CI-22843

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./store/database/... ./app/drivers/...` passes
- [ ] On a dev runner, claim a hotpool/predictor instance and confirm the `capacity_reservation.created_at` column is populated with a recent timestamp (not 0) and the purger does not reap the reservation immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)