### PR TITLE
fix: [CI-22929] log LE HTTP request payload on transport failure

### DIFF
--- a/app/lehelper/lehelper.go
+++ b/app/lehelper/lehelper.go
@@ -2,15 +2,37 @@ package lehelper
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httputil"
 	"time"
 
 	"github.com/harness/lite-engine/api"
 	lehttp "github.com/harness/lite-engine/cli/client"
+	"github.com/sirupsen/logrus"
 
 	"github.com/drone-runners/drone-runner-aws/app/cloudinit"
 	"github.com/drone-runners/drone-runner-aws/app/oshelp"
 	"github.com/drone-runners/drone-runner-aws/types"
 )
+
+type loggingTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		dump, _ := httputil.DumpRequestOut(req, true)
+		logrus.WithField("request", string(dump)).Traceln("LE HTTP request")
+		logrus.WithError(err).Errorln("LE HTTP request failed")
+		return resp, err
+	}
+
+	dumpResp, _ := httputil.DumpResponse(resp, true)
+	logrus.WithField("response", string(dumpResp)).Traceln("LE HTTP response")
+	return resp, nil
+}
 
 const (
 	LiteEnginePort = 9079
@@ -67,7 +89,12 @@ func GetClient(instance *types.Instance, serverName string, liteEnginePort int64
 	if mock {
 		return lehttp.NewNoopClient(&api.PollStepResponse{}, nil, time.Duration(mockTimeoutSecs)*time.Second, 0, 0), nil
 	}
-	return lehttp.NewHTTPClient(leURL,
+	c, err := lehttp.NewHTTPClient(leURL,
 		serverName, string(instance.CACert),
 		string(instance.TLSCert), string(instance.TLSKey))
+	if err != nil {
+		return nil, err
+	}
+	c.Client.Transport = &loggingTransport{wrapped: c.Client.Transport}
+	return c, nil
 }

--- a/app/lehelper/lehelper.go
+++ b/app/lehelper/lehelper.go
@@ -20,15 +20,12 @@ type loggingTransport struct {
 }
 
 func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-
 	resp, err := t.wrapped.RoundTrip(req)
 	if err != nil {
 		dump, _ := httputil.DumpRequestOut(req, true)
-		logrus.WithField("request", string(dump)).Traceln("LE HTTP request")
-		logrus.WithError(err).Errorln("LE HTTP request failed")
+		logrus.WithError(err).WithField("request", string(dump)).Debugln("LE HTTP request failed")
 		return resp, err
 	}
-
 	return resp, nil
 }
 

--- a/app/lehelper/lehelper.go
+++ b/app/lehelper/lehelper.go
@@ -29,8 +29,6 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, err
 	}
 
-	dumpResp, _ := httputil.DumpResponse(resp, true)
-	logrus.WithField("response", string(dumpResp)).Traceln("LE HTTP response")
 	return resp, nil
 }
 

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -467,8 +467,8 @@ type EnvConfig struct {
 	}
 
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.171/"`
-		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.171/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.175/"`
+		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.175/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.171
+	github.com/harness/lite-engine v0.5.175
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.171 h1:vsIEo6/iFhSUU3qTO9OLa+nLNucM7NrY05OtmJybsLI=
-github.com/harness/lite-engine v0.5.171/go.mod h1:oNFh+/Jw86rtOWo4wF2/RsjMFG0wxubpwNKqBGTXpJQ=
+github.com/harness/lite-engine v0.5.175 h1:cZ5O++MJEgmVDNB32ahBavc1yXuLLvsIUQdDHgO/EGY=
+github.com/harness/lite-engine v0.5.175/go.mod h1:krHDq6oSVEkRNuN4GSiJmmjSit3kI7VArUqDDBy56GE=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0 h1:J4Na3luGEI1jHnpYzsnDH9/XzVpXPX6x19SGiJZojvo=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0/go.mod h1:dGKnH3sg7UvBL2OztrqIusmsiBknSNy1Y5+9M2J241Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=


### PR DESCRIPTION
## What

Adds debug instrumentation to surface the outgoing HTTP request whenever a
call from the runner to lite-engine (LE) fails at the transport layer
(connection refused, TLS handshake error, timeout, EOF, etc.).

Also bumps `github.com/harness/lite-engine` from `v0.5.171` → `v0.5.175`,
along with the matching default download URLs in `DRONE_LITE_ENGINE_PATH`
and `DRONE_LITE_ENGINE_FALLBACK_PATH` so VMs install the LE version the
runner is built against.

## Why

CI-22929: LE HTTP calls (health/setup/poll-step/start-step) intermittently
fail and today the logs only show the error string — there's no visibility
into the request that failed (URL, headers, body), which makes
transport-level issues hard to triage.

## How

Wraps the `*http.Client.Transport` returned by `lehttp.NewHTTPClient` with
a `loggingTransport` (an `http.RoundTripper` decorator) in
`app/lehelper/lehelper.go`. On a failed `RoundTrip`, it dumps the request
via `httputil.DumpRequestOut` and logs it alongside the error at `Debug`.
Because every LE call goes through `http.Client.Do → Transport.RoundTrip`,
every existing call site picks this up automatically — no API changes.

## Scope

- `app/lehelper/lehelper.go` — add `loggingTransport`, wire into `GetClient`
- `command/config/config.go` — bump default LE download URLs to v0.5.175
- `go.mod` / `go.sum` — bump `github.com/harness/lite-engine` to v0.5.175

## Risk / Rollout

- Logging only fires on transport errors, so happy-path overhead is one
  extra `RoundTrip` indirection per LE call.
- No behavioral change on the request itself; the wrapped transport's
  response and error are returned unchanged.
- Intended as a debug aid for CI-22929; can be reverted independently of
  the LE bump.

## Test plan

- [ ] Build runner with this change and run an existing CI job — confirm
      no regression on a successful LE setup/poll-step flow.
- [ ] Force a failure (e.g. block port 9079 on the VM, or use a bad cert)
      and confirm the request dump + error appear in the runner logs at
      Debug level.
- [ ] Verify `v0.5.175` LE binary is downloaded by VMs using default config.