### PR TITLE
feat: [CI-22952]: bump lite-engine dependency from v0.5.171 to v0.5.176

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -467,8 +467,8 @@ type EnvConfig struct {
 	}
 
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.171/"`
-		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.171/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.176/"`
+		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.176/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.171
+	github.com/harness/lite-engine v0.5.176
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.171 h1:vsIEo6/iFhSUU3qTO9OLa+nLNucM7NrY05OtmJybsLI=
-github.com/harness/lite-engine v0.5.171/go.mod h1:oNFh+/Jw86rtOWo4wF2/RsjMFG0wxubpwNKqBGTXpJQ=
+github.com/harness/lite-engine v0.5.176 h1:ItYHJxkeJyAMo4jcvqCnO9sdyQufmThjljC2JSuj66c=
+github.com/harness/lite-engine v0.5.176/go.mod h1:krHDq6oSVEkRNuN4GSiJmmjSit3kI7VArUqDDBy56GE=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0 h1:J4Na3luGEI1jHnpYzsnDH9/XzVpXPX6x19SGiJZojvo=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0/go.mod h1:dGKnH3sg7UvBL2OztrqIusmsiBknSNy1Y5+9M2J241Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=


### PR DESCRIPTION
## Summary
Bumps the `github.com/harness/lite-engine` dependency from v0.5.171 to v0.5.176.

## Changes Made
- Updated `DRONE_LITE_ENGINE_PATH` default URL to v0.5.176
- Updated `DRONE_LITE_ENGINE_FALLBACK_PATH` default URL to v0.5.176
- Bumped `go.mod` dependency to `github.com/harness/lite-engine v0.5.176`
- Updated `go.sum` checksums

## Testing
- `go build ./...` passes
- All unit tests pass

## Related Issues/Logs
- Ticket: [CI-22952](https://harness.atlassian.net/browse/CI-22952)

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-22952]: https://harness.atlassian.net/browse/CI-22952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ