### PR TITLE
[fix]: [CI-gcp-429]: Back off GCP API calls on rate limit errors

### DIFF
--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -393,6 +393,7 @@ func (p *config) findReservationZone(ctx context.Context, reservationID string) 
 	logr := logger.FromContext(ctx)
 
 	for _, z := range p.allZones() {
+		waitIfGCPPaused()
 		_, err := p.service.Reservations.Get(p.projectID, z, reservationID).Context(ctx).Do()
 		if err == nil {
 			return z, nil
@@ -400,6 +401,10 @@ func (p *config) findReservationZone(ctx context.Context, reservationID string) 
 		// If not found in this zone, continue to next zone
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusNotFound {
 			continue
+		}
+		if isRateLimited(err) {
+			pauseGCPOn429()
+			return "", fmt.Errorf("google: rate limited while finding reservation zone: %w", err)
 		}
 		// For other errors, log and continue
 		logr.WithError(err).Warnf("google: error checking reservation in zone %s", z)
@@ -823,7 +828,12 @@ func (p *config) DestroyInstanceAndStorage(ctx context.Context, instances []*typ
 	var failedInstances []*types.Instance
 	var lastErr error
 
-	for _, instance := range instances {
+	for i, instance := range instances {
+		if i > 0 && isGCPPaused() {
+			waitIfGCPPaused()
+			time.Sleep(gcpDestroyBatchPace)
+		}
+
 		logr := logger.FromContext(ctx).
 			WithField("id", instance.ID).
 			WithField("cloud", types.Google)
@@ -1135,6 +1145,11 @@ func (p *config) findInstanceZone(ctx context.Context, instanceID string) (
 			continue
 		}
 
+		if isRateLimited(err) {
+			pauseGCPOn429()
+			return "", fmt.Errorf("google: rate limited while finding instance zone: %w", err)
+		}
+
 		// Non-404 error (rate limit, API error, etc.) - track it
 		allNotFound = false
 		lastErr = err
@@ -1161,6 +1176,7 @@ func (p *config) waitZoneOperation(ctx context.Context, name, zone string) error
 			return ctx.Err()
 		default:
 		}
+		waitIfGCPPaused()
 		ctxGcp, cancel := context.WithTimeout(ctx, operationGetTimeout*time.Second)
 		client := p.service
 		op, err := client.ZoneOperations.Get(p.projectID, zone, name).Context(ctxGcp).Do()
@@ -1171,11 +1187,14 @@ func (p *config) waitZoneOperation(ctx context.Context, name, zone string) error
 				return errors.New("not Found")
 			}
 			if shouldRetry(err) {
+				if isRateLimited(err) {
+					pauseGCPOn429()
+				}
 				logger.FromContext(ctx).
 					WithField("name", name).
 					WithField("zone", zone).
 					Warnf("google: wait operation failed with retryable error: %s. retrying\n", err)
-				time.Sleep(time.Second)
+				waitIfGCPPaused()
 				continue
 			}
 			return err
@@ -1376,10 +1395,14 @@ func (p *config) deleteFirewallRulesByID(ctx context.Context, firewallProject st
 
 func (p *config) waitGlobalOperation(ctx context.Context, name string) error {
 	for {
+		waitIfGCPPaused()
 		op, err := p.service.GlobalOperations.Get(p.projectID, name).Context(ctx).Do()
 		if err != nil {
 			if shouldRetry(err) {
-				time.Sleep(time.Second)
+				if isRateLimited(err) {
+					pauseGCPOn429()
+				}
+				waitIfGCPPaused()
 				continue
 			}
 			return err
@@ -1413,19 +1436,7 @@ func (p *config) getZone(ctx context.Context, instance *types.Instance) (string,
 		return zone, nil
 	}
 
-	// validate if instance is present
-	_, findInstanceErr := p.getInstance(ctx, p.projectID, instance.Zone, instance.ID)
-	if findInstanceErr != nil {
-		var googleErr *googleapi.Error
-		if errors.As(findInstanceErr, &googleErr) && googleErr.Code == http.StatusNotFound {
-			return "", ErrInstanceNotFound
-		}
-		return "", fmt.Errorf(
-			"google: failed to find instance in zone %s, error: %w",
-			instance.Zone,
-			findInstanceErr,
-		)
-	}
+	// Trust the stored zone; delete handles 404 if the VM is already gone.
 	return instance.Zone, nil
 }
 
@@ -1481,13 +1492,23 @@ func shouldRetry(err error) bool {
 
 func retry[T any](ctx context.Context, attempts, sleepSecs int, f func() (T, error)) (result T, err error) {
 	for i := 0; i < attempts; i++ {
+		waitIfGCPPaused()
 		if i > 0 {
 			logger.FromContext(ctx).Warnf("retrying after error: %s\n", err)
-			time.Sleep(time.Duration(sleepSecs) * time.Second)
+			sleep := retrySleepForError(err, sleepSecs)
+			select {
+			case <-ctx.Done():
+				return result, ctx.Err()
+			case <-time.After(sleep):
+			}
 		}
 		result, err = f()
 		if err == nil {
 			return result, nil
+		}
+
+		if isRateLimited(err) {
+			pauseGCPOn429()
 		}
 
 		if !shouldRetry(err) {

--- a/app/drivers/google/driver_test.go
+++ b/app/drivers/google/driver_test.go
@@ -1,0 +1,111 @@
+package google
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+func TestGetZone_TrustsStoredZone(t *testing.T) {
+	p := &config{projectID: "test-project"}
+	zone, err := p.getZone(context.Background(), &types.Instance{
+		ID:   "123",
+		Zone: "us-central1-a",
+	})
+	if err != nil {
+		t.Fatalf("getZone returned error: %v", err)
+	}
+	if zone != "us-central1-a" {
+		t.Fatalf("getZone = %q, want us-central1-a", zone)
+	}
+}
+
+func TestFindInstanceZone_StopsOnRateLimit(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	oldInitial := gcpPauseInitialDur
+	gcpPauseInitialDur = 10 * time.Millisecond
+	defer func() {
+		gcpPauseInitialDur = oldInitial
+		resetGCPRateLimitStateForTest()
+	}()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Rate limit exceeded","errors":[{"reason":"rateLimitExceeded"}]}}`))
+	}))
+	defer srv.Close()
+
+	service, err := compute.NewService(
+		context.Background(),
+		option.WithoutAuthentication(),
+		option.WithEndpoint(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("compute.NewService: %v", err)
+	}
+
+	p := &config{
+		projectID: "test-project",
+		zones:     []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+		service:   service,
+	}
+
+	_, err = p.findInstanceZone(context.Background(), "instance-1")
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	// getInstance retries 429 up to getRetries times in the first zone, then zone walk stops.
+	if calls.Load() != int32(getRetries) {
+		t.Fatalf("expected zone walk to stop after first zone (%d API calls), got %d", getRetries, calls.Load())
+	}
+}
+
+func TestDestroyInstanceAndStorage_PacesWhenPaused(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	gcpPausedUntil.Store(time.Now().Add(250 * time.Millisecond).UnixNano())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	service, err := compute.NewService(
+		context.Background(),
+		option.WithoutAuthentication(),
+		option.WithEndpoint(srv.URL),
+	)
+	if err != nil {
+		t.Fatalf("compute.NewService: %v", err)
+	}
+
+	p := &config{projectID: "test-project", service: service}
+	instances := []*types.Instance{
+		{ID: "vm-1", Zone: "us-central1-a"},
+		{ID: "vm-2", Zone: "us-central1-a"},
+	}
+
+	start := time.Now()
+	_, err = p.DestroyInstanceAndStorage(context.Background(), instances, nil)
+	elapsed := time.Since(start)
+
+	// Not found is treated as success for destroy; pacing should add delay between instances.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("expected pacing between batched deletes while paused, only took %v", elapsed)
+	}
+	if err != nil {
+		t.Fatalf("DestroyInstanceAndStorage returned error: %v", err)
+	}
+}

--- a/app/drivers/google/ratelimit.go
+++ b/app/drivers/google/ratelimit.go
@@ -1,0 +1,120 @@
+package google
+
+import (
+	"errors"
+	"math/rand"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+const (
+	gcpDestroyBatchPace = 200 * time.Millisecond
+)
+
+var (
+	gcpPauseInitialDur = 5 * time.Second
+	gcpPauseMaxDur     = 60 * time.Second
+
+	gcpPausedUntil atomic.Int64
+	gcpPauseLevel  atomic.Int32
+)
+
+func isRateLimited(err error) bool {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	if gerr.Code == http.StatusTooManyRequests {
+		return true
+	}
+	for _, item := range gerr.Errors {
+		switch item.Reason {
+		case "rateLimitExceeded", "quotaExceeded", "userRateLimitExceeded":
+			return true
+		}
+	}
+	return false
+}
+
+func isGCPPaused() bool {
+	until := gcpPausedUntil.Load()
+	return until > 0 && until > time.Now().UnixNano()
+}
+
+// pauseGCPOn429 extends a process-wide pause so concurrent GCP callers back off together.
+func pauseGCPOn429() {
+	level := gcpPauseLevel.Add(1)
+	if level > 4 {
+		gcpPauseLevel.Store(4)
+		level = 4
+	}
+
+	pause := gcpPauseInitialDur << (level - 1)
+	if pause > gcpPauseMaxDur {
+		pause = gcpPauseMaxDur
+	}
+	pause = addJitter(pause)
+
+	until := time.Now().Add(pause).UnixNano()
+	for {
+		old := gcpPausedUntil.Load()
+		if until <= old {
+			return
+		}
+		if gcpPausedUntil.CompareAndSwap(old, until) {
+			return
+		}
+	}
+}
+
+func waitIfGCPPaused() {
+	for {
+		until := gcpPausedUntil.Load()
+		if until == 0 {
+			return
+		}
+		remaining := time.Until(time.Unix(0, until))
+		if remaining <= 0 {
+			gcpPausedUntil.Store(0)
+			gcpPauseLevel.Store(0)
+			return
+		}
+		sleep := remaining
+		if sleep > 500*time.Millisecond {
+			sleep = 500 * time.Millisecond
+		}
+		time.Sleep(sleep)
+	}
+}
+
+func addJitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	// ±25% jitter to avoid synchronized retries.
+	jitter := time.Duration(rand.Int63n(int64(d/2))) - d/4 //nolint:mnd
+	return d + jitter
+}
+
+func retrySleepForError(err error, defaultSecs int) time.Duration {
+	if isRateLimited(err) {
+		level := gcpPauseLevel.Load()
+		if level <= 0 {
+			level = 1
+		}
+		sleep := gcpPauseInitialDur << (level - 1)
+		if sleep > gcpPauseMaxDur {
+			sleep = gcpPauseMaxDur
+		}
+		return addJitter(sleep)
+	}
+	return time.Duration(defaultSecs) * time.Second
+}
+
+func resetGCPRateLimitStateForTest() {
+	gcpPausedUntil.Store(0)
+	gcpPauseLevel.Store(0)
+}

--- a/app/drivers/google/ratelimit_test.go
+++ b/app/drivers/google/ratelimit_test.go
@@ -1,0 +1,143 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsRateLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "429", err: &googleapi.Error{Code: http.StatusTooManyRequests}, want: true},
+		{
+			name: "quota reason",
+			err:  &googleapi.Error{Code: 403, Errors: []googleapi.ErrorItem{{Reason: "quotaExceeded"}}},
+			want: true,
+		},
+		{name: "500", err: &googleapi.Error{Code: 500}, want: false},
+		{name: "404", err: &googleapi.Error{Code: 404}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRateLimited(tt.err); got != tt.want {
+				t.Fatalf("isRateLimited() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPauseGCPOn429_ExtendsPauseWindow(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	oldInitial := gcpPauseInitialDur
+	gcpPauseInitialDur = 50 * time.Millisecond
+	defer func() {
+		gcpPauseInitialDur = oldInitial
+		resetGCPRateLimitStateForTest()
+	}()
+
+	pauseGCPOn429()
+	firstUntil := gcpPausedUntil.Load()
+	if firstUntil <= time.Now().UnixNano() {
+		t.Fatal("expected active pause after first 429")
+	}
+
+	pauseGCPOn429()
+	secondUntil := gcpPausedUntil.Load()
+	if secondUntil <= firstUntil {
+		t.Fatal("expected pause window to extend on repeated 429")
+	}
+}
+
+func TestWaitIfGCPPaused_ClearsAfterExpiry(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	gcpPausedUntil.Store(time.Now().Add(30 * time.Millisecond).UnixNano())
+
+	start := time.Now()
+	waitIfGCPPaused()
+	if elapsed := time.Since(start); elapsed < 20*time.Millisecond {
+		t.Fatalf("expected to wait for pause expiry, only waited %v", elapsed)
+	}
+	if isGCPPaused() {
+		t.Fatal("expected pause to clear after expiry")
+	}
+}
+
+func TestRetry_UsesLongerBackoffOn429(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	oldInitial := gcpPauseInitialDur
+	gcpPauseInitialDur = 80 * time.Millisecond
+	defer func() {
+		gcpPauseInitialDur = oldInitial
+		resetGCPRateLimitStateForTest()
+	}()
+
+	var calls atomic.Int32
+	start := time.Now()
+	_, err := retry(context.Background(), 2, 1, func() (struct{}, error) {
+		if calls.Add(1) == 1 {
+			return struct{}{}, &googleapi.Error{Code: http.StatusTooManyRequests}
+		}
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("retry returned error: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 attempts, got %d", calls.Load())
+	}
+	if elapsed := time.Since(start); elapsed < 60*time.Millisecond {
+		t.Fatalf("expected longer backoff on 429, only waited %v", elapsed)
+	}
+}
+
+func TestRetry_StillUsesDefaultSleepOn5xx(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	oldInitial := gcpPauseInitialDur
+	gcpPauseInitialDur = 500 * time.Millisecond
+	defer func() {
+		gcpPauseInitialDur = oldInitial
+		resetGCPRateLimitStateForTest()
+	}()
+
+	var calls atomic.Int32
+	start := time.Now()
+	_, err := retry(context.Background(), 2, 1, func() (struct{}, error) {
+		if calls.Add(1) == 1 {
+			return struct{}{}, &googleapi.Error{Code: 503}
+		}
+		return struct{}{}, nil
+	})
+	if err != nil {
+		t.Fatalf("retry returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond || elapsed > 1500*time.Millisecond {
+		t.Fatalf("expected ~1s sleep for 5xx retry, got %v", elapsed)
+	}
+}
+
+func TestRetry_DoesNotRetryNonRetryableError(t *testing.T) {
+	resetGCPRateLimitStateForTest()
+	var calls atomic.Int32
+	_, err := retry(context.Background(), 3, 1, func() (struct{}, error) {
+		calls.Add(1)
+		return struct{}{}, errors.New("permanent failure")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected single attempt, got %d", calls.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- Add a process-wide GCP pause (`ratelimit.go`) triggered on 429/quota errors so concurrent API callers back off together instead of retry-storming
- Stop `findInstanceZone` / `findReservationZone` zone walks immediately on rate limit (avoids N×zone read amplification)
- Trust stored `instance.Zone` on destroy (skip pre-delete `Instances.Get`; delete 404 already handled)
- On 429: `retry()` uses exponential backoff; `waitZoneOperation` / `waitGlobalOperation` respect shared pause instead of tight 1s loops
- Pace batched destroys only while pause is active (no steady-state impact when quota is healthy)

## Test plan

- [x] `go test ./app/drivers/google/...` (86 tests)
- [x] `TestFindInstanceZone_StopsOnRateLimit` — zone walk stops after first zone under 429 (3 retries, not 3 zones)
- [x] `TestGetZone_TrustsStoredZone` — no API call when zone is populated
- [x] `TestDestroyInstanceAndStorage_PacesWhenPaused` — batch pacing only when paused
- [x] Rate limit helper tests for pause extension, backoff, and retry behavior


Made with [Cursor](https://cursor.com)