### PR TITLE
feat: [CI-23811]: set end-date TTL on AWS capacity reservations

### DIFF
--- a/app/drivers/amazon/driver.go
+++ b/app/drivers/amazon/driver.go
@@ -350,7 +350,7 @@ func (p *amazonConfig) ReserveCapacity(ctx context.Context, opts *drtypes.Instan
 		InstancePlatform:      types.CapacityReservationInstancePlatform(instancePlatform),
 		AvailabilityZone:      aws.String(reqCfg.availabilityZone),
 		InstanceCount:         aws.Int32(1),
-		EndDateType:           types.EndDateTypeUnlimited,          // No end date
+		EndDateType:           types.EndDateTypeUnlimited,          // No end date unless a TTL is set below
 		InstanceMatchCriteria: types.InstanceMatchCriteriaTargeted, // Instances must explicitly target this reservation
 		TagSpecifications: []types.TagSpecification{
 			{
@@ -358,6 +358,21 @@ func (p *amazonConfig) ReserveCapacity(ctx context.Context, opts *drtypes.Instan
 				Tags:         convertTags(buildHarnessTags(opts)),
 			},
 		},
+	}
+
+	// Bound the reservation lifetime with an end date so a leaked reservation
+	// (e.g. runner crashes before DestroyCapacity runs) is auto-reclaimed by AWS
+	// instead of billing indefinitely. This mirrors the GCP DeleteAfterDuration TTL.
+	// Note: AWS ends a limited reservation within ~1h of EndDate (min duration 1h),
+	// and any instance already launched into the reservation keeps running as a
+	// normal On-Demand instance — it is not stopped when the reservation ends.
+	if opts.CapacityReservationTTL > 0 {
+		endDate := time.Now().Add(time.Duration(opts.CapacityReservationTTL) * time.Second)
+		input.EndDateType = types.EndDateTypeLimited
+		input.EndDate = aws.Time(endDate)
+		logr.WithField("end_date", endDate).
+			WithField("ttl_seconds", opts.CapacityReservationTTL).
+			Infoln("amazon: setting end date on capacity reservation")
 	}
 
 	result, err := client.CreateCapacityReservation(ctx, input)


### PR DESCRIPTION
## Problem

The AWS driver's `ReserveCapacity` hard-coded `EndDateType: Unlimited` on every EC2 Capacity Reservation. If the normal teardown path (`DestroyCapacity` → `CancelCapacityReservation`) never runs — runner crash, dropped destroy call — the reservation lingers indefinitely and keeps billing for reserved capacity.

The GCP driver already guards against this via `DeleteAfterDuration` (sourced from `CapacityReservationTTL`). AWS had no equivalent, even though `CapacityReservationTTL` already flows all the way through to `InstanceCreateOpts`.

## Change

Consume the existing `opts.CapacityReservationTTL` in the AWS `ReserveCapacity` path:

- When `CapacityReservationTTL > 0`: set `EndDateType = Limited` and `EndDate = now + TTL`.
- Otherwise: keep the current `Unlimited` behavior (no change for configs without a TTL).

## Semantics / safety

- When an AWS reservation reaches its `EndDate` (or is cancelled), AWS only releases the **unused** reserved capacity. Any instance already launched into the reservation keeps running as a normal On-Demand instance — it is **not** stopped or terminated. This is a cost backstop, not a VM lifecycle change.
- AWS ends a limited reservation within ~1h of `EndDate` (minimum duration 1h), so the TTL is best-effort rather than a precise deadline (unlike GCP's `DeleteAfterDuration`).

## Files

- `app/drivers/amazon/driver.go`

Jira: [CI-23811](https://harness.atlassian.net/browse/CI-23811) · Related: CI-23810 (GCP per-pool reservation timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-23811]: https://harness.atlassian.net/browse/CI-23811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ