### PR TITLE
fix: retry GCE quota (403) errors and destroy leaked VMs before dropp…

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -1199,10 +1199,14 @@ func (d *DistributedManager) executeInstanceCleanup(
 	return successfulInstances, nil
 }
 
-// forceDeleteLeakedInstances removes rows that have been stuck past 2 * maxAge.
+// forceDeleteLeakedInstances handles rows that have been stuck past 2 * maxAge.
 // These are instances the driver has been unable to destroy across many retry
-// ticks; keeping them forever would bloat the table and skew pool metrics.
-// We log loudly so operators can reconcile the cloud side.
+// ticks. Before we let go of the DB row we make one last attempt to destroy the
+// cloud VM, so we do not orphan a running instance that nothing will ever reap.
+// Rows are claimed atomically (DELETE ... RETURNING) so peer purger nodes do not
+// double-process them; any row whose cloud destroy still fails is re-inserted so
+// it stays tracked and can be retried/reconciled on a later tick, rather than
+// being silently forgotten while the VM keeps running.
 func (d *DistributedManager) forceDeleteLeakedInstances(
 	ctx context.Context,
 	pool *poolEntry,
@@ -1251,9 +1255,39 @@ func (d *DistributedManager) forceDeleteLeakedInstances(
 		WithField("instance_names", leakedNames).
 		WithField("max_age_seconds", int64(maxAge.Seconds())).
 		WithField("destroy_caller", "distributed_purger:leak_candidate").
-		Warnf("distributed dlite: purger: force-deleting %d instance_leak_candidate row(s) older than 2x maxAge; verify cloud-side cleanup", len(leaked))
+		Warnf("distributed dlite: purger: destroying %d instance_leak_candidate(s) older than 2x maxAge before dropping their rows", len(leaked))
 
-	d.destroyCapacity(ctx, leaked)
+	// Last-chance cloud cleanup before we relinquish the rows. Destroy treats a
+	// NotFound VM as success (not returned in failedInstances), so already-gone
+	// instances are correctly treated as destroyed.
+	failedInstances, destroyErr := pool.Driver.Destroy(ctx, leaked)
+	if destroyErr != nil {
+		logr.WithError(destroyErr).
+			WithField("destroy_caller", "distributed_purger:leak_candidate").
+			Warnf("distributed dlite: purger: cloud destroy failed for %d leak-candidate(s); their rows will be re-inserted for retry", len(failedInstances))
+	}
+
+	// Re-insert rows whose cloud VM could not be destroyed so they remain
+	// tracked and get retried/reconciled instead of leaking.
+	failedIDs := make(map[string]bool, len(failedInstances))
+	for _, inst := range failedInstances {
+		failedIDs[inst.ID] = true
+		if createErr := d.instanceStore.Create(ctx, inst); createErr != nil {
+			logr.WithError(createErr).
+				WithField("instance_id", inst.ID).
+				WithField("instance_name", inst.Name).
+				Error("distributed dlite: purger: failed to re-insert undestroyed leak-candidate; VM may leak, reconcile cloud-side")
+		}
+	}
+
+	// Free capacity only for instances we actually destroyed.
+	destroyed := leaked[:0]
+	for _, inst := range leaked {
+		if !failedIDs[inst.ID] {
+			destroyed = append(destroyed, inst)
+		}
+	}
+	d.destroyCapacity(ctx, destroyed)
 }
 
 func (d *DistributedManager) destroyCapacity(ctx context.Context, instances []*types.Instance) {

--- a/app/drivers/distributed_manager_purger_test.go
+++ b/app/drivers/distributed_manager_purger_test.go
@@ -39,6 +39,16 @@ func newPurgerFakeStore(seed ...*types.Instance) *purgerFakeStore {
 	return s
 }
 
+// Create re-inserts a row into the in-memory map. The purger uses this to
+// re-track leak-candidates whose cloud destroy failed.
+func (s *purgerFakeStore) Create(_ context.Context, instance *types.Instance) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copied := *instance
+	s.instances[instance.ID] = &copied
+	return nil
+}
+
 func (s *purgerFakeStore) snapshot() map[string]*types.Instance {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -216,7 +226,7 @@ func TestDistributedPurger_ExecuteInstanceCleanup_DestroyFailureKeepsRow(t *test
 
 func TestDistributedPurger_ForceDeleteLeakCandidateAt2xMaxAge(t *testing.T) {
 	// Dummy data:
-	//   leak: older than 2 * maxAge  -> force-deleted regardless of state
+	//   leak: older than 2 * maxAge  -> claimed & destroyed by the leak path
 	//   fresh: within maxAge         -> claimed & destroyed on this tick
 	//   borderline: older than maxAge but younger than 2x -> also claimed this tick
 	now := time.Now()
@@ -246,14 +256,41 @@ func TestDistributedPurger_ForceDeleteLeakCandidateAt2xMaxAge(t *testing.T) {
 	assert.NoError(t, err)
 
 	snap := store.snapshot()
-	assert.NotContains(t, snap, "leak", "row older than 2 * maxAge must be force-deleted before claim")
+	assert.NotContains(t, snap, "leak", "leak-candidate row must be dropped once its VM is destroyed")
 	assert.NotContains(t, snap, "fresh", "successful row should be deleted")
 	assert.NotContains(t, snap, "borderline", "successful row should be deleted")
 
-	// The leak-candidate row must be removed BEFORE the claim so the driver
-	// never sees it on this tick. (It will eventually be reconciled out-of-band.)
-	assert.NotContains(t, sawInDestroy, "leak", "leak-candidate should be force-deleted before driver.Destroy is called")
-	assert.ElementsMatch(t, []string{"fresh", "borderline"}, sawInDestroy, "driver.Destroy should see only in-window rows")
+	// The leak-candidate VM must be handed to driver.Destroy before its row is
+	// dropped, so we never orphan a running instance that nothing will reap.
+	assert.Contains(t, sawInDestroy, "leak", "leak-candidate must be destroyed cloud-side before its row is dropped")
+	assert.ElementsMatch(t, []string{"leak", "fresh", "borderline"}, sawInDestroy, "driver.Destroy should see leak-candidate and in-window rows")
+}
+
+func TestDistributedPurger_LeakCandidateReinsertedWhenDestroyFails(t *testing.T) {
+	// If the cloud destroy of a leak-candidate fails (e.g. quota exhaustion),
+	// its row must be re-inserted so it stays tracked and gets retried, instead
+	// of being silently dropped while the VM keeps running.
+	now := time.Now()
+	maxAge := 5 * time.Minute
+
+	leak := &types.Instance{ID: "leak", Name: "vm-leak", Pool: "pool1", State: types.StateTerminating, Started: now.Add(-3 * maxAge).Unix()}
+	store := newPurgerFakeStore(leak)
+
+	driver := &flexibleMockDriver{
+		driverName: "mock",
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			// Report every instance as failed to destroy.
+			return instances, errors.New("quota exceeded")
+		},
+	}
+
+	d, pool := newPurgerTestManager(store, driver)
+	d.forceDeleteLeakedInstances(context.Background(), pool, "busy", maxAge)
+
+	snap := store.snapshot()
+	if assert.Contains(t, snap, "leak", "undestroyed leak-candidate must be re-inserted so it is not orphaned") {
+		assert.Equal(t, "vm-leak", snap["leak"].Name)
+	}
 }
 
 func TestDistributedPurger_ForceDelete_NoopWhenMaxAgeZero(t *testing.T) {

--- a/app/drivers/google/driver.go
+++ b/app/drivers/google/driver.go
@@ -35,13 +35,16 @@ import (
 var _ drivers.Driver = (*config)(nil)
 
 const (
-	maxInstanceNameLen  = 63
-	randStrLen          = 5
-	tagRetries          = 3
-	getRetries          = 3
-	insertRetries       = 3
-	deleteRetries       = 3
-	secSleep            = 1
+	maxInstanceNameLen = 63
+	randStrLen         = 5
+	tagRetries         = 3
+	getRetries         = 5
+	insertRetries      = 3
+	deleteRetries      = 5
+	secSleep           = 1
+	// maxRetrySleep caps the exponential backoff used by retry() so a run of
+	// retryable failures (e.g. quota exhaustion) cannot block a call unbounded.
+	maxRetrySleep       = 16 * time.Second
 	tagRetrySleepMs     = 1000
 	operationGetTimeout = 30
 	maxStockoutAttempts = 3
@@ -1739,23 +1742,49 @@ func (p *config) deprioritizeStockoutZones(candidates []createCandidate, machine
 }
 
 func shouldRetry(err error) bool {
-	switch e := err.(type) {
-	case *googleapi.Error:
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
 		// Retry on 429 and 5xx, according to
 		// https://cloud.google.com/storage/docs/exponential-backoff.
-		return e.Code == 429 || (e.Code >= 500 && e.Code < 600)
-	case interface{ Temporary() bool }:
-		return e.Temporary()
-	default:
+		if gerr.Code == 429 || (gerr.Code >= 500 && gerr.Code < 600) {
+			return true
+		}
+		// GCE surfaces quota/rate-limit exhaustion as HTTP 403 with a
+		// rateLimitExceeded/quotaExceeded reason (NOT 429). These are transient
+		// and must be retried with backoff; otherwise create/delete calls fail
+		// immediately under load and leak VMs.
+		if gerr.Code == http.StatusForbidden {
+			for i := range gerr.Errors {
+				switch gerr.Errors[i].Reason {
+				case "rateLimitExceeded", "userRateLimitExceeded", "quotaExceeded":
+					return true
+				}
+			}
+		}
 		return false
 	}
+	var tmp interface{ Temporary() bool }
+	if errors.As(err, &tmp) {
+		return tmp.Temporary()
+	}
+	return false
 }
 
-func retry[T any](ctx context.Context, attempts, sleepSecs int, f func() (T, error)) (result T, err error) {
+// retry invokes f up to attempts times, sleeping between retryable failures
+// with exponential backoff (base baseSleepSecs, doubling each attempt, capped
+// at maxRetrySleep) plus random jitter. Jitter is important under quota
+// pressure: a fixed sleep synchronizes every runner's retries into the same
+// per-minute window and keeps the rate limit saturated.
+func retry[T any](ctx context.Context, attempts, baseSleepSecs int, f func() (T, error)) (result T, err error) {
 	for i := 0; i < attempts; i++ {
 		if i > 0 {
-			logger.FromContext(ctx).Warnf("retrying after error: %s\n", err)
-			time.Sleep(time.Duration(sleepSecs) * time.Second)
+			backoff := backoffDuration(baseSleepSecs, i)
+			logger.FromContext(ctx).Warnf("retrying after error (attempt %d/%d, sleeping %s): %s\n", i+1, attempts, backoff, err)
+			select {
+			case <-ctx.Done():
+				return result, ctx.Err()
+			case <-time.After(backoff):
+			}
 		}
 		result, err = f()
 		if err == nil {
@@ -1767,6 +1796,22 @@ func retry[T any](ctx context.Context, attempts, sleepSecs int, f func() (T, err
 		}
 	}
 	return result, err
+}
+
+// backoffDuration returns the sleep for retry attempt n (n >= 1): an
+// exponential base*2^(n-1) capped at maxRetrySleep, with up to 25% random
+// jitter added to desynchronize concurrent callers.
+func backoffDuration(baseSleepSecs, n int) time.Duration {
+	base := time.Duration(baseSleepSecs) * time.Second
+	if base <= 0 {
+		base = time.Second
+	}
+	backoff := base << (n - 1)
+	if backoff <= 0 || backoff > maxRetrySleep {
+		backoff = maxRetrySleep
+	}
+	jitter := time.Duration(rand.Int63n(int64(backoff)/4 + 1)) //nolint:gosec // jitter, not security-sensitive
+	return backoff + jitter
 }
 
 // buildLabelsWithGitspace creates a copy of the instance labels and adds

--- a/app/drivers/google/driver_test.go
+++ b/app/drivers/google/driver_test.go
@@ -757,3 +757,75 @@ func TestPoolYAMLTopologies_Deprioritization(t *testing.T) {
 		}
 	}
 }
+
+// --- shouldRetry ---
+
+func TestShouldRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"429 rate limited", &googleapi.Error{Code: http.StatusTooManyRequests}, true},
+		{"500 server error", &googleapi.Error{Code: http.StatusInternalServerError}, true},
+		{"503 unavailable", &googleapi.Error{Code: http.StatusServiceUnavailable}, true},
+		{"404 not found", &googleapi.Error{Code: http.StatusNotFound}, false},
+		{"400 bad request", &googleapi.Error{Code: http.StatusBadRequest}, false},
+		{"403 plain forbidden (no rate-limit reason)", &googleapi.Error{Code: http.StatusForbidden}, false},
+		{
+			"403 rateLimitExceeded",
+			&googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "rateLimitExceeded"}}},
+			true,
+		},
+		{
+			"403 quotaExceeded",
+			&googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "quotaExceeded"}}},
+			true,
+		},
+		{
+			"403 userRateLimitExceeded",
+			&googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "userRateLimitExceeded"}}},
+			true,
+		},
+		{
+			"403 wrapped rateLimitExceeded",
+			fmt.Errorf("google: failed to delete the VM: %w", &googleapi.Error{Code: http.StatusForbidden, Errors: []googleapi.ErrorItem{{Reason: "rateLimitExceeded"}}}),
+			true,
+		},
+		{"non-google error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRetry(tt.err); got != tt.want {
+				t.Fatalf("shouldRetry(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- backoffDuration ---
+
+func TestBackoffDuration(t *testing.T) {
+	base := 1 // second
+	// Attempt n should be within [base*2^(n-1), base*2^(n-1)*1.25], capped at maxRetrySleep*1.25.
+	for n := 1; n <= 8; n++ {
+		got := backoffDuration(base, n)
+		expLower := (time.Duration(base) * time.Second) << (n - 1)
+		if expLower > maxRetrySleep {
+			expLower = maxRetrySleep
+		}
+		upper := expLower + expLower/4
+		if got < expLower || got > upper {
+			t.Fatalf("backoffDuration(%d, %d) = %s, want within [%s, %s]", base, n, got, expLower, upper)
+		}
+	}
+}
+
+func TestBackoffDurationCapped(t *testing.T) {
+	// A large attempt count must not overflow or exceed the cap (+ jitter).
+	got := backoffDuration(1, 40)
+	if got > maxRetrySleep+maxRetrySleep/4 {
+		t.Fatalf("backoffDuration cap exceeded: got %s, cap %s", got, maxRetrySleep)
+	}
+}


### PR DESCRIPTION
…ing rows

Two fixes targeting stale/leaked CI VMs in cie-hosted-vm-paid-prod, whose root cause was Compute Engine per-region API quota (rate-limit) exhaustion.

1. shouldRetry now treats HTTP 403 with a rateLimitExceeded/userRateLimit Exceeded/quotaExceeded reason as retryable. GCE returns 403 (not 429) for quota exhaustion, so these previously failed on the first attempt, leaving VMs that could neither be re-fetched after insert nor deleted. retry() now uses exponential backoff with jitter (capped at maxRetrySleep) and honors context cancellation, instead of a fixed 1s sleep that synchronized every runner's retries into the same per-minute quota window. Read/delete retry counts raised 3 -> 5 now that backoff makes extra attempts affordable.

2. forceDeleteLeakedInstances now attempts a cloud Destroy before dropping the DB row. Rows whose VM cannot be destroyed are re-inserted so they stay tracked and get retried/reconciled, instead of being silently dropped while the VM keeps running (the previous behavior only logged "verify cloud-side cleanup" and orphaned the VM). Capacity is freed only for VMs actually destroyed.

Adds unit tests for 403 rate-limit classification, backoff bounds/cap, the destroy-before-drop path, and the re-insert-on-destroy-failure path.

# Commit Checklist

Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
