### PR TITLE
fix: [CI-23809]: fix chi chi vuln

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/drone/runner-go v1.13.0
 	github.com/drone/signal v1.0.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-chi/chi/v5 v5.2.4
+	github.com/go-chi/chi/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chi/chi/v5 v5.2.4 h1:WtFKPHwlywe8Srng8j2BhOD9312j9cGUxG1SP4V2cR4=
-github.com/go-chi/chi/v5 v5.2.4/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
+github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=


### PR DESCRIPTION
## Summary
Bumps `github.com/go-chi/chi/v5` from `v5.2.4` to `v5.3.1` to close three CVEs
flagged against the `drone/drone-runner-aws:latest` image.

## CVEs Closed
| CVE | Severity | Fixed in |
|---|---|---|
| GHSA-9g5q-2w5x-hmxf | High | v5.3.0 |
| GHSA-rjr7-jggh-pgcp | High | v5.3.0 |
| GHSA-3fxj-6jh8-hvhx | Medium | v5.3.0 |

All three are IP spoofing issues in `middleware.RealIP` and `Request.RemoteAddr`
resolution. This project uses `NewWrapResponseWriter` and `Recoverer`, not
`RealIP`, so no runtime behavior change is expected.

Picked `v5.3.1` (latest patch) over the ticket's suggested `v5.3.0` to include
subsequent upstream fixes at no extra risk.

## Files Changed
* `go.mod` (1 line)
* `go.sum` (2 lines)

## Verification
* `go build ./...` passed
* `go test ./command/harness/...` passed
* Built a test image `abhijeetharness/drone-runner-aws:ci-23809-chi-v5.3.1`
  and re-ran the Ondemand Vulnerability Scanner. Result: 0 Critical, 0 chi
  findings. All three ticket CVEs confirmed absent.

## Related
Jira: [CI-23809](https://harness.atlassian.net/browse/CI-23809)



[CI-23809]: https://harness.atlassian.net/browse/CI-23809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ