### PR TITLE
refactor: [CI-23851]: move warm-claim identity labels overlay to hosted VMs flow

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -278,6 +278,7 @@ func (d *DistributedManager) provisionFromReservedCapacity(
 	if reservedCapacity.InstanceID != "" {
 		inst, err := d.Find(ctx, reservedCapacity.InstanceID)
 		if err == nil {
+			refreshClaimIdentityLabels(ctx, pool, inst, setupParams, timeout)
 			return inst, true, nil
 		}
 		logger.FromContext(ctx).
@@ -433,6 +434,9 @@ func (d *DistributedManager) provisionFromPool(
 					WithField("source", string(inst.Source)).
 					Infoln("provision: skipping replenishment for non-pool instance")
 			}
+
+			refreshClaimIdentityLabels(ctx, pool, inst, setupParams, timeout)
+
 			capacity = &types.CapacityReservation{
 				InstanceID: inst.ID,
 				PoolName:   poolName,

--- a/app/drivers/identity_labels_test.go
+++ b/app/drivers/identity_labels_test.go
@@ -5,6 +5,8 @@
 package drivers
 
 import (
+	"context"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -213,3 +215,67 @@ func TestBuildClaimIdentityLabels(t *testing.T) {
 	}
 }
 
+func TestRefreshClaimIdentityLabels(t *testing.T) {
+	setupParams := &types.SetupInstanceParams{
+		AccountID:           "Acc-AbC123",
+		StageRuntimeID:      "StAgE-1",
+		PipelineExecutionID: "PiPe-1_XYZ",
+	}
+	inst := &types.Instance{ID: "inst-1"}
+
+	t.Run("calls SetLabels with the built overlay", func(t *testing.T) {
+		var gotInst *types.Instance
+		var gotLabels map[string]string
+		var called bool
+		mock := &flexibleMockDriver{
+			SetLabelsFunc: func(_ context.Context, i *types.Instance, labels map[string]string) error {
+				called = true
+				gotInst = i
+				gotLabels = labels
+				return nil
+			},
+		}
+		pool := &poolEntry{Pool: Pool{Driver: mock}}
+
+		refreshClaimIdentityLabels(context.Background(), pool, inst, setupParams, int64(3600))
+
+		if !called {
+			t.Fatal("expected SetLabels to be called")
+		}
+		if gotInst != inst {
+			t.Errorf("SetLabels got instance %v, want %v", gotInst, inst)
+		}
+		wantIdentity := map[string]string{
+			LabelAccountID:           "acc-abc123",
+			LabelStageExecutionID:    "stage-1",
+			LabelPipelineExecutionID: "pipe-1_xyz",
+		}
+		for k, v := range wantIdentity {
+			if gotLabels[k] != v {
+				t.Errorf("label %q: got %q, want %q", k, gotLabels[k], v)
+			}
+		}
+		if _, ok := gotLabels[LabelCreatedAt]; !ok {
+			t.Errorf("missing %q label", LabelCreatedAt)
+		}
+		if _, ok := gotLabels[LabelLongRunning]; !ok {
+			t.Errorf("missing %q label", LabelLongRunning)
+		}
+	})
+
+	t.Run("swallows SetLabels error (log-and-continue)", func(t *testing.T) {
+		mock := &flexibleMockDriver{
+			SetLabelsFunc: func(_ context.Context, _ *types.Instance, _ map[string]string) error {
+				return errors.New("boom")
+			},
+		}
+		pool := &poolEntry{Pool: Pool{Driver: mock}}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("helper panicked on SetLabels error: %v", r)
+			}
+		}()
+		refreshClaimIdentityLabels(context.Background(), pool, inst, setupParams, int64(3600))
+	})
+}

--- a/app/drivers/manager_extended_test.go
+++ b/app/drivers/manager_extended_test.go
@@ -174,6 +174,7 @@ type flexibleMockDriver struct {
 	HibernateFunc                 func(ctx context.Context, instanceID, poolName, zone string) error
 	StartFunc                     func(ctx context.Context, instance *types.Instance, poolName string) (string, error)
 	SetTagsFunc                   func(ctx context.Context, instance *types.Instance, tags map[string]string) error
+	SetLabelsFunc                 func(ctx context.Context, instance *types.Instance, labels map[string]string) error
 	PingFunc                      func(ctx context.Context) error
 	LogsFunc                      func(ctx context.Context, instanceID string) (string, error)
 	GetFullyQualifiedImageFunc    func(ctx context.Context, config *types.VMImageConfig) (string, error)
@@ -238,7 +239,10 @@ func (m *flexibleMockDriver) SetTags(ctx context.Context, instance *types.Instan
 	return nil
 }
 
-func (m *flexibleMockDriver) SetLabels(_ context.Context, _ *types.Instance, _ map[string]string) error {
+func (m *flexibleMockDriver) SetLabels(ctx context.Context, instance *types.Instance, labels map[string]string) error {
+	if m.SetLabelsFunc != nil {
+		return m.SetLabelsFunc(ctx, instance, labels)
+	}
 	return nil
 }
 

--- a/app/drivers/provisioner.go
+++ b/app/drivers/provisioner.go
@@ -175,18 +175,6 @@ func (m *Manager) provisionFromPool(
 	}
 	pool.Unlock()
 
-	// Refresh GCP identity labels on the warmed instance. Pool-fill created
-	// the VM with only constant labels (no stage/pipeline). Log-and-continue:
-	// the build should not fail when a best-effort label write fails.
-	// Non-GCP drivers return nil.
-	overlay := buildClaimIdentityLabels(setupParams, timeout)
-	if len(overlay) > 0 {
-		if labelErr := pool.Driver.SetLabels(ctx, inst, overlay); labelErr != nil {
-			logger.FromContext(ctx).WithError(labelErr).
-				WithField("instance_id", inst.ID).
-				Warnln("provision: failed to set identity labels on warm instance; continuing")
-		}
-	}
 	return inst, nil, true, "", nil
 }
 
@@ -603,6 +591,23 @@ func buildClaimIdentityLabels(setupParams *types.SetupInstanceParams, timeout in
 		}
 	}
 	return labels
+}
+
+// refreshClaimIdentityLabels overlays per-stage GCP identity labels onto a
+// warm-pool VM at claim time. Pool-fill created the VM with only constant
+// labels (no stage/pipeline). Log-and-continue: the build must not fail when
+// a best-effort label write fails. Non-GCP drivers return nil overlays and
+// this is a no-op for them.
+func refreshClaimIdentityLabels(ctx context.Context, pool *poolEntry, inst *types.Instance, setupParams *types.SetupInstanceParams, timeout int64) {
+	overlay := buildClaimIdentityLabels(setupParams, timeout)
+	if len(overlay) == 0 {
+		return
+	}
+	if labelErr := pool.Driver.SetLabels(ctx, inst, overlay); labelErr != nil {
+		logger.FromContext(ctx).WithError(labelErr).
+			WithField("instance_id", inst.ID).
+			Warnln("provision: failed to set identity labels on warm instance; continuing")
+	}
 }
 
 // pinBinaryDownloadsToHarness rewrites every binary download URL to the canonical


### PR DESCRIPTION
## Summary
Moves the GCP identity labels overlay from the non-distributed `Manager.provisionFromPool` warm-claim path to the `DistributedManager` (hosted VMs) flow. Extracts the overlay into a shared helper so both hosted claim paths use one code path.

## Why
Today the label overlay runs on `Manager.provisionFromPool` (non-distributed), which is not the code path hosted VMs take. Hosted VMs go through `DistributedManager.provisionFromPool` (warm claim) and `provisionFromReservedCapacity` (init-task with reservation), neither of which refresh identity labels on a warm-pool VM. That means SREs querying `gcloud compute instances list --filter='labels.harness-stage-execution-id=...'` cannot find hosted VMs claimed from a warm pool.

## Changes
- Extract the overlay call into `refreshClaimIdentityLabels(ctx, pool, inst, setupParams, timeout)` in [`provisioner.go`](../blob/CI-23851-hosted-claim-identity-labels/app/drivers/provisioner.go).
- Call the helper from `DistributedManager.provisionFromPool` warm-claim branch (Case 2).
- Call the helper from `DistributedManager.provisionFromReservedCapacity` when the pre-reserved instance is found (init-task-with-reservation path).
- Drop the corresponding block from `Manager.provisionFromPool` (non-distributed no longer overlays labels on warm claim).
- Add `TestRefreshClaimIdentityLabels` covering the `SetLabels` call and the log-and-continue error path. Wire a `SetLabelsFunc` hook into `flexibleMockDriver` so the helper can be observed.

## Base
This PR is stacked on top of [#897](https://github.com/drone-runners/drone-runner-aws/pull/897) (`CI-23851-remove-claim-identity-metadata`). Merge #897 first, then this can be retargeted to `master`.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./app/drivers/...` clean
- [x] `gofmt -l` clean
- [x] `go test ./app/drivers/ -run TestRefreshClaimIdentityLabels` passes (both sub-tests)
- [x] Full `go test ./app/drivers/` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)