### PR TITLE
fix: [CI-22905]: fix tenant-resolved variant filtering and hibernate operations (follow-up)

### DIFF
--- a/app/drivers/distributed_manager.go
+++ b/app/drivers/distributed_manager.go
@@ -335,10 +335,12 @@ func (d *DistributedManager) provisionFromPool(
 	}
 	setupParams.TenantID = tenantID
 
-	// Variant filtering: select all matching variants in priority order based on provisionParams
+	// Variant filtering: select matching variants from the tenant-resolved list so per-tenant
+	// variant_id overrides (machine_type, disk, etc.) are honored on provision.
 	var matchedVariants []*types.PoolVariant
-	if len(pool.PoolVariants) > 0 {
-		matchedVariants = d.filterVariants(ctx, pool, provisionParams)
+	tenantVariants := pool.VariantsForTenant(tenantID)
+	if len(tenantVariants) > 0 {
+		matchedVariants = d.filterVariants(ctx, pool, provisionParams, tenantVariants)
 		if len(matchedVariants) > 0 {
 			// Apply the first (highest priority) variant config for new instance creation
 			applyVariantToSetupParams(setupParams, matchedVariants[0])
@@ -486,21 +488,25 @@ func shouldReplenishInstance(inst *types.Instance) bool {
 }
 
 // filterVariants returns all matching variants in priority order based on provisionParams criteria.
+// variants is the candidate list (typically pool.VariantsForTenant); callers must pass the
+// tenant-resolved slice so per-tenant machine_type/disk/image overrides are honored.
 // Step 1: Filter by ResourceClass AND NestedVirtualization (both required). Returns nil if no matches.
 // Step 2: When the provision request has a non-empty fully qualified image name, refine by image:
 // variants with a matching image name are preferred; otherwise variants with no image name are used.
 // If nothing qualifies in step 2, returns nil (no fallback to all step-1 candidates).
 // When the provision image is empty, step 2 is skipped and step 1 candidates are returned.
 // The order preserves the original pool configuration order.
-func (d *DistributedManager) filterVariants(ctx context.Context, pool *poolEntry, provisionParams *types.ProvisionParams) []*types.PoolVariant {
+func (d *DistributedManager) filterVariants(
+	ctx context.Context, pool *poolEntry, provisionParams *types.ProvisionParams, variants []types.PoolVariant,
+) []*types.PoolVariant {
 	logr := logger.FromContext(ctx).WithField("pool", pool.Name)
 
 	// Step 1: Filter by ResourceClass AND NestedVirtualization (both required)
 	var candidates []*types.PoolVariant
-	for i := range pool.PoolVariants {
-		if pool.PoolVariants[i].ResourceClass == provisionParams.ResourceClass &&
-			pool.PoolVariants[i].NestedVirtualization == provisionParams.NestedVirtualization {
-			candidates = append(candidates, &pool.PoolVariants[i])
+	for i := range variants {
+		if variants[i].ResourceClass == provisionParams.ResourceClass &&
+			variants[i].NestedVirtualization == provisionParams.NestedVirtualization {
+			candidates = append(candidates, &variants[i])
 		}
 	}
 
@@ -581,6 +587,9 @@ func applyVariantToSetupParams(setupParams *types.SetupInstanceParams, variant *
 	}
 	if variant.GPU {
 		setupParams.GPU = true
+	}
+	if variant.Hibernate {
+		setupParams.Hibernate = true
 	}
 	// Set VariantID for tracking
 	setupParams.VariantID = variant.VariantID
@@ -699,10 +708,11 @@ func (d *DistributedManager) setupInstanceWithHibernate(
 
 		// Step 3: Attempt to hibernate the instance
 		shouldHibernate := false
+		tenantDriver := pool.DriverForTenant(inst.TenantID)
 		if setupParams != nil && setupParams.VariantID != "" && setupParams.VariantID != defaultVariantID {
 			shouldHibernate = setupParams.Hibernate
 		} else {
-			shouldHibernate = pool.Driver.CanHibernate()
+			shouldHibernate = tenantDriver.CanHibernate()
 		}
 		err = d.hibernate(ctx, pool.Name, inst, shouldHibernate)
 		if err != nil {
@@ -747,7 +757,7 @@ func (d *DistributedManager) hibernate(
 
 	var hibernateErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		hibernateErr = pool.Driver.Hibernate(ctx, claimedInstance.ID, poolName, claimedInstance.Zone)
+		hibernateErr = pool.DriverForTenant(claimedInstance.TenantID).Hibernate(ctx, claimedInstance.ID, poolName, claimedInstance.Zone)
 		if hibernateErr == nil {
 			break // Success, exit retry loop
 		}

--- a/app/drivers/distributed_manager_test.go
+++ b/app/drivers/distributed_manager_test.go
@@ -373,7 +373,7 @@ func TestFilterVariant(t *testing.T) {
 			}
 
 			dm := &DistributedManager{}
-			results := dm.filterVariants(ctx, pool, tt.provisionParams)
+			results := dm.filterVariants(ctx, pool, tt.provisionParams, tt.variants)
 
 			if tt.expectedIDs == nil {
 				if results != nil {
@@ -743,7 +743,7 @@ func TestFilterVariants_Prod_LinuxAmd64(t *testing.T) {
 			}
 
 			dm := &DistributedManager{}
-			results := dm.filterVariants(ctx, pool, tt.provisionParams)
+			results := dm.filterVariants(ctx, pool, tt.provisionParams, prodVariants)
 
 			if tt.expectedIDs == nil {
 				if results != nil {
@@ -774,6 +774,61 @@ func variantIDList(variants []*types.PoolVariant) []string {
 		ids[i] = v.VariantID
 	}
 	return ids
+}
+
+// TestFilterVariants_TenantPartialMachineTypeOverride simulates provision: resolve tenant
+// variants (already merged by variant_id) and apply the matched variant's machine_type.
+func TestFilterVariants_TenantPartialMachineTypeOverride(t *testing.T) {
+	ctx := context.Background()
+	baseVariants := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", ResourceClass: "large", MachineType: "c4d-standard-8-lssd", DiskType: "hyperdisk-balanced",
+		}},
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_xlarge", ResourceClass: "xlarge", MachineType: "c4d-standard-16-lssd",
+		}},
+	}
+	// Already-merged tenant variants (as ResolveTenants/mergeVariants would produce).
+	tenantVariants := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", ResourceClass: "large", MachineType: "c4d-standard-8", DiskType: "hyperdisk-balanced",
+		}},
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_xlarge", ResourceClass: "xlarge", MachineType: "c4d-standard-16-lssd",
+		}},
+	}
+
+	pool := &poolEntry{
+		Pool: Pool{
+			Name:            "gcp-mt",
+			PoolVariants:    baseVariants,
+			AccountToTenant: map[string]string{"acctA": "acctA"},
+			TenantDrivers: map[string]Driver{
+				types.DefaultTenantID: &mockDriver{},
+				"acctA":               &mockDriver{},
+			},
+			Tenants: []TenantPool{
+				{ID: types.DefaultTenantID, PoolVariants: baseVariants},
+				{ID: "acctA", PoolVariants: tenantVariants},
+			},
+			Driver: &mockDriver{},
+		},
+	}
+
+	dm := &DistributedManager{}
+	params := &types.ProvisionParams{ResourceClass: "large"}
+	matched := dm.filterVariants(ctx, pool, params, pool.VariantsForTenant(pool.ResolveTenant("acctA")))
+	if len(matched) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matched))
+	}
+	setup := &types.SetupInstanceParams{}
+	applyVariantToSetupParams(setup, matched[0])
+	if setup.MachineType != "c4d-standard-8" {
+		t.Errorf("machine_type: got %q want c4d-standard-8", setup.MachineType)
+	}
+	if setup.DiskType != "hyperdisk-balanced" {
+		t.Errorf("disk_type should inherit: got %q", setup.DiskType)
+	}
 }
 
 func TestApplyVariantToSetupParams(t *testing.T) {
@@ -850,6 +905,20 @@ func TestApplyVariantToSetupParams(t *testing.T) {
 				DiskSize:    200,
 				DiskType:    "pd-balanced",
 				VariantID:   "v4",
+			},
+		},
+		{
+			name:          "apply hibernate from variant",
+			initialParams: &types.SetupInstanceParams{},
+			variant: &types.PoolVariant{
+				SetupInstanceParams: types.SetupInstanceParams{
+					VariantID: "v-hib",
+					Hibernate: true,
+				},
+			},
+			expectedParams: &types.SetupInstanceParams{
+				VariantID: "v-hib",
+				Hibernate: true,
 			},
 		},
 		{

--- a/app/drivers/hibernator.go
+++ b/app/drivers/hibernator.go
@@ -102,7 +102,7 @@ func (m *Manager) hibernateOrStopWithRetries(
 		return fmt.Errorf("hibernate: pool name %q not found", poolName)
 	}
 
-	if !pool.Driver.CanHibernate() && !fallbackStop {
+	if !pool.DriverForTenant(instance.TenantID).CanHibernate() && !fallbackStop {
 		return nil
 	}
 

--- a/app/drivers/pool.go
+++ b/app/drivers/pool.go
@@ -102,6 +102,29 @@ func (p *Pool) DriverForTenant(tenantID string) Driver {
 	return p.Driver
 }
 
+// VariantsForTenant returns the resolved variants for the given tenant. Multi-tenant pools
+// store per-tenant variants on TenantPool (base variants merged with tenant overrides by
+// variant_id). Single-tenant pools use Pool.PoolVariants.
+func (p *Pool) VariantsForTenant(tenantID string) []types.PoolVariant {
+	if !p.IsMultiTenant() {
+		return p.PoolVariants
+	}
+	if tenantID == "" {
+		tenantID = types.DefaultTenantID
+	}
+	for i := range p.Tenants {
+		if p.Tenants[i].ID == tenantID {
+			return p.Tenants[i].PoolVariants
+		}
+	}
+	for i := range p.Tenants {
+		if p.Tenants[i].ID == types.DefaultTenantID {
+			return p.Tenants[i].PoolVariants
+		}
+	}
+	return p.PoolVariants
+}
+
 type Driver interface {
 	ReserveCapacity(ctx context.Context, opts *types.InstanceCreateOpts) (instance *types.CapacityReservation, err error)
 	DestroyCapacity(ctx context.Context, capacity *types.CapacityReservation) (err error)

--- a/app/drivers/pool_test.go
+++ b/app/drivers/pool_test.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/drone-runners/drone-runner-aws/types"
@@ -75,5 +76,101 @@ func TestPool_DriverForTenant_SingleTenantFallback(t *testing.T) {
 	}
 	if p.DriverForTenant(types.DefaultTenantID) != def {
 		t.Errorf("expected pool driver for default tenant on single-tenant pool")
+	}
+}
+
+func TestPool_VariantsForTenant(t *testing.T) {
+	baseVariants := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "c4d-standard-8-lssd"},
+	}}
+	tenantVariants := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "c4d-standard-8"},
+	}}
+
+	p := &Pool{
+		Name:         "gcp",
+		PoolVariants: baseVariants,
+		AccountToTenant: map[string]string{
+			"acctA": "acctA",
+		},
+		TenantDrivers: map[string]Driver{
+			types.DefaultTenantID: &mockDriver{},
+			"acctA":               &mockDriver{},
+		},
+		Tenants: []TenantPool{
+			{ID: types.DefaultTenantID, PoolVariants: baseVariants},
+			{ID: "acctA", PoolVariants: tenantVariants},
+		},
+	}
+
+	got := p.VariantsForTenant("acctA")
+	if len(got) != 1 || got[0].MachineType != "c4d-standard-8" {
+		t.Errorf("acctA: expected tenant machine_type c4d-standard-8, got %+v", got)
+	}
+	got = p.VariantsForTenant(types.DefaultTenantID)
+	if len(got) != 1 || got[0].MachineType != "c4d-standard-8-lssd" {
+		t.Errorf("default: expected base machine_type, got %+v", got)
+	}
+	got = p.VariantsForTenant("unknown")
+	if len(got) != 1 || got[0].MachineType != "c4d-standard-8-lssd" {
+		t.Errorf("unknown: expected default tenant variants, got %+v", got)
+	}
+	got = p.VariantsForTenant("")
+	if len(got) != 1 || got[0].MachineType != "c4d-standard-8-lssd" {
+		t.Errorf("empty tenantID: expected default tenant variants, got %+v", got)
+	}
+}
+
+func TestPool_VariantsForTenant_SingleTenant(t *testing.T) {
+	variants := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "v1", MachineType: "t3.large"},
+	}}
+	p := &Pool{Name: "aws", PoolVariants: variants}
+	got := p.VariantsForTenant("anything")
+	if len(got) != 1 || got[0].MachineType != "t3.large" {
+		t.Errorf("expected pool variants, got %+v", got)
+	}
+}
+
+func TestDestroyByTenant_RoutesToTenantDrivers(t *testing.T) {
+	var destroyedDefault, destroyedAcctA int
+	def := &flexibleMockDriver{
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			destroyedDefault += len(instances)
+			return nil, nil
+		},
+	}
+	acct := &flexibleMockDriver{
+		DestroyFunc: func(_ context.Context, instances []*types.Instance) ([]*types.Instance, error) {
+			destroyedAcctA += len(instances)
+			return nil, nil
+		},
+	}
+	p := &Pool{
+		Name:   "gcp",
+		Driver: def,
+		TenantDrivers: map[string]Driver{
+			types.DefaultTenantID: def,
+			"acctA":               acct,
+		},
+	}
+	instances := []*types.Instance{
+		{ID: "1", TenantID: types.DefaultTenantID},
+		{ID: "2", TenantID: "acctA"},
+		{ID: "3", TenantID: "acctA"},
+		{ID: "4", TenantID: ""}, // empty → default
+	}
+	failed, err := destroyByTenant(context.Background(), p, instances)
+	if err != nil {
+		t.Fatalf("destroyByTenant: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Errorf("unexpected failed: %v", failed)
+	}
+	if destroyedDefault != 2 {
+		t.Errorf("default driver: destroyed %d want 2", destroyedDefault)
+	}
+	if destroyedAcctA != 2 {
+		t.Errorf("acctA driver: destroyed %d want 2", destroyedAcctA)
 	}
 }

--- a/app/drivers/tenant_hibernate_test.go
+++ b/app/drivers/tenant_hibernate_test.go
@@ -1,0 +1,138 @@
+package drivers
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+// TestDistributedHibernate_UsesTenantDriver proves multi-tenant hibernate calls the
+// instance's tenant driver, not the pool default driver.
+func TestDistributedHibernate_UsesTenantDriver(t *testing.T) {
+	var defaultCalls, tenantCalls atomic.Int32
+
+	def := &flexibleMockDriver{
+		canHibernate: true,
+		HibernateFunc: func(context.Context, string, string, string) error {
+			defaultCalls.Add(1)
+			return nil
+		},
+	}
+	acct := &flexibleMockDriver{
+		canHibernate: true,
+		HibernateFunc: func(context.Context, string, string, string) error {
+			tenantCalls.Add(1)
+			return nil
+		},
+	}
+
+	inst := &types.Instance{
+		ID:       "vm-1",
+		Pool:     "gcp-mt",
+		TenantID: "acctA",
+		State:    types.StateCreated,
+		Zone:     "us-central1-a",
+	}
+
+	store := &mockInstanceStore{
+		FindAndClaimFunc: func(
+			_ context.Context, _ *types.QueryParams, newState types.InstanceState, _ []types.InstanceState, _ bool,
+		) (*types.Instance, error) {
+			claimed := *inst
+			claimed.State = newState
+			return &claimed, nil
+		},
+		UpdateFunc: func(_ context.Context, _ *types.Instance) error { return nil },
+	}
+
+	mgr := &Manager{
+		instanceStore: store,
+		poolMap: map[string]*poolEntry{
+			"gcp-mt": {
+				Pool: Pool{
+					Name:   "gcp-mt",
+					Driver: def,
+					TenantDrivers: map[string]Driver{
+						types.DefaultTenantID: def,
+						"acctA":               acct,
+					},
+				},
+			},
+		},
+	}
+	dm := &DistributedManager{Manager: *mgr}
+
+	if err := dm.hibernate(context.Background(), "gcp-mt", inst, true); err != nil {
+		t.Fatalf("hibernate: %v", err)
+	}
+	if tenantCalls.Load() != 1 {
+		t.Errorf("tenant driver Hibernate calls: got %d want 1", tenantCalls.Load())
+	}
+	if defaultCalls.Load() != 0 {
+		t.Errorf("default driver must not be used: got %d calls", defaultCalls.Load())
+	}
+}
+
+// TestHibernateOrStop_UsesTenantCanHibernate verifies Suspend/hibernate gating consults the
+// tenant driver, not the pool default.
+func TestHibernateOrStop_UsesTenantCanHibernate(t *testing.T) {
+	var hibernateCalls atomic.Int32
+	def := &flexibleMockDriver{canHibernate: false}
+	acct := &flexibleMockDriver{
+		canHibernate: true,
+		HibernateFunc: func(context.Context, string, string, string) error {
+			hibernateCalls.Add(1)
+			return nil
+		},
+	}
+
+	inst := &types.Instance{
+		ID:       "vm-2",
+		Pool:     "gcp-mt",
+		TenantID: "acctA",
+		State:    types.StateCreated,
+		Zone:     "us-central1-a",
+	}
+	store := &mockInstanceStore{
+		FindFunc: func(_ context.Context, id string) (*types.Instance, error) {
+			out := *inst
+			out.ID = id
+			return &out, nil
+		},
+		UpdateFunc: func(_ context.Context, _ *types.Instance) error { return nil },
+	}
+
+	mgr := &Manager{
+		instanceStore: store,
+		poolMap: map[string]*poolEntry{
+			"gcp-mt": {
+				Pool: Pool{
+					Name:   "gcp-mt",
+					Driver: def,
+					TenantDrivers: map[string]Driver{
+						types.DefaultTenantID: def,
+						"acctA":               acct,
+					},
+				},
+			},
+		},
+	}
+
+	if err := mgr.hibernateOrStopWithRetries(context.Background(), "gcp-mt", inst, false); err != nil {
+		t.Fatalf("hibernateOrStopWithRetries: %v", err)
+	}
+	if hibernateCalls.Load() != 1 {
+		t.Errorf("expected tenant hibernate (CanHibernate=true), got %d calls", hibernateCalls.Load())
+	}
+
+	// Same pool default tenant cannot hibernate and fallbackStop=false → no-op.
+	defInst := &types.Instance{ID: "vm-3", Pool: "gcp-mt", TenantID: types.DefaultTenantID, State: types.StateCreated}
+	if err := mgr.hibernateOrStopWithRetries(context.Background(), "gcp-mt", defInst, false); err != nil {
+		t.Fatalf("default tenant: %v", err)
+	}
+	if hibernateCalls.Load() != 1 {
+		t.Errorf("default tenant should skip hibernate: got %d calls", hibernateCalls.Load())
+	}
+}

--- a/app/drivers/tenant_lifecycle_test.go
+++ b/app/drivers/tenant_lifecycle_test.go
@@ -1,0 +1,93 @@
+package drivers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+// TestTenantLifecycle_VariantMachineTypeE2E asserts provision applies the tenant-resolved
+// variant machine_type / hibernate flags, while the default tenant keeps base variants.
+func TestTenantLifecycle_VariantMachineTypeE2E(t *testing.T) {
+	baseVariants := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", ResourceClass: "large",
+			MachineType: "c4d-standard-8-lssd", DiskType: "hyperdisk-balanced", DiskSize: 100, Hibernate: false,
+		}},
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_xlarge", ResourceClass: "xlarge",
+			MachineType: "c4d-standard-16-lssd", DiskType: "hyperdisk-balanced", DiskSize: 100,
+		}},
+	}
+	tenantVariants := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", ResourceClass: "large",
+			MachineType: "c4d-standard-8", DiskType: "hyperdisk-balanced", DiskSize: 100, Hibernate: true,
+		}},
+		{SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_xlarge", ResourceClass: "xlarge",
+			MachineType: "c4d-standard-16-lssd", DiskType: "hyperdisk-balanced", DiskSize: 100,
+		}},
+	}
+
+	def := &flexibleMockDriver{canHibernate: false}
+	acct := &flexibleMockDriver{canHibernate: true}
+	p := &Pool{
+		Name:            "linux-amd64-gcp",
+		PoolVariants:    baseVariants,
+		Driver:          def,
+		AccountToTenant: map[string]string{"acctA": "acctA"},
+		TenantDrivers: map[string]Driver{
+			types.DefaultTenantID: def,
+			"acctA":               acct,
+		},
+		Tenants: []TenantPool{
+			{ID: types.DefaultTenantID, PoolVariants: baseVariants},
+			{ID: "acctA", PoolVariants: tenantVariants},
+		},
+	}
+
+	entry := &poolEntry{Pool: *p}
+	dm := &DistributedManager{}
+	ctx := context.Background()
+
+	acctID := p.ResolveTenant("acctA")
+	matched := dm.filterVariants(ctx, entry, &types.ProvisionParams{ResourceClass: "large"}, p.VariantsForTenant(acctID))
+	if len(matched) != 1 {
+		t.Fatalf("expected 1 matched variant, got %d", len(matched))
+	}
+	setup := &types.SetupInstanceParams{TenantID: acctID}
+	applyVariantToSetupParams(setup, matched[0])
+	if setup.MachineType != "c4d-standard-8" {
+		t.Errorf("create machine_type: got %q want c4d-standard-8", setup.MachineType)
+	}
+	if setup.VariantID != "variant_large" {
+		t.Errorf("variant_id: got %q", setup.VariantID)
+	}
+	if !setup.Hibernate {
+		t.Error("create hibernate: expected true from tenant variant")
+	}
+
+	defMatched := dm.filterVariants(ctx, entry, &types.ProvisionParams{ResourceClass: "large"}, p.VariantsForTenant(types.DefaultTenantID))
+	defSetup := &types.SetupInstanceParams{}
+	applyVariantToSetupParams(defSetup, defMatched[0])
+	if defSetup.MachineType != "c4d-standard-8-lssd" {
+		t.Errorf("default create machine_type: got %q", defSetup.MachineType)
+	}
+
+	xlarge := dm.filterVariants(ctx, entry, &types.ProvisionParams{ResourceClass: "xlarge"}, p.VariantsForTenant(acctID))
+	if len(xlarge) != 1 || xlarge[0].MachineType != "c4d-standard-16-lssd" {
+		t.Errorf("inherited variant_xlarge: %+v", xlarge)
+	}
+
+	if p.DriverForTenant("acctA") == p.DriverForTenant(types.DefaultTenantID) {
+		t.Error("expected distinct tenant drivers")
+	}
+	if !p.DriverForTenant("acctA").CanHibernate() {
+		t.Error("tenant driver should CanHibernate")
+	}
+	if p.DriverForTenant(types.DefaultTenantID).CanHibernate() {
+		t.Error("default driver should not CanHibernate")
+	}
+}

--- a/app/poolfile/tenant_config_test.go
+++ b/app/poolfile/tenant_config_test.go
@@ -361,3 +361,75 @@ func networkProxyURLFromDriver(t *testing.T, d drivers.Driver) string {
 	}
 	return ncs.Index(0).FieldByName("proxyURL").String()
 }
+
+// TestProcessPool_TenantVariantReplaceByID verifies tenant variants replace matching
+// base entries by variant_id through ProcessPool / VariantsForTenant.
+func TestProcessPool_TenantVariantReplaceByID(t *testing.T) {
+	yaml := `
+version: "1"
+instances:
+  - name: linux-amd64-gcp
+    type: google
+    pool: 1
+    limit: 10
+    platform:
+      os: linux
+      arch: amd64
+    spec:
+      account:
+        project_id: proj-base
+      image: img-base
+      machine_type: e2-standard-4
+    variants:
+      - variant_id: variant_large
+        resource_class: large
+        machine_type: c4d-standard-8-lssd
+        disk_type: hyperdisk-balanced
+        disk_size: 100
+        pool: 1
+      - variant_id: variant_xlarge
+        resource_class: xlarge
+        machine_type: c4d-standard-16-lssd
+        disk_type: hyperdisk-balanced
+        disk_size: 100
+        pool: 1
+    tenants:
+      - ids: [acctA]
+        spec:
+          machine_type: c4d-standard-8
+          hibernate: true
+        variants:
+          - variant_id: variant_large
+            resource_class: large
+            machine_type: c4d-standard-8
+            disk_type: hyperdisk-balanced
+            disk_size: 100
+            pool: 1
+`
+	pf, err := config.Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pools, err := ProcessPool(pf, "runner", types.Passwords{})
+	if err != nil {
+		t.Fatalf("ProcessPool: %v", err)
+	}
+	p := pools[0]
+
+	tenantVars := p.VariantsForTenant("acctA")
+	if len(tenantVars) != 2 {
+		t.Fatalf("expected 2 variants after replace-by-id, got %d", len(tenantVars))
+	}
+	wantEqual(t, "variant_large machine_type", tenantVars[0].MachineType, "c4d-standard-8")
+	wantEqual(t, "variant_large disk_type", tenantVars[0].DiskType, "hyperdisk-balanced")
+	wantEqual(t, "variant_large resource_class", tenantVars[0].ResourceClass, "large")
+	wantEqual(t, "variant_xlarge machine_type", tenantVars[1].MachineType, "c4d-standard-16-lssd")
+
+	defVars := p.VariantsForTenant(types.DefaultTenantID)
+	wantEqual(t, "default variant_large machine_type", defVars[0].MachineType, "c4d-standard-8-lssd")
+
+	// Spec-level hibernate merge is baked into per-tenant drivers.
+	if p.DriverForTenant("acctA") == p.DriverForTenant(types.DefaultTenantID) {
+		t.Error("expected distinct drivers after tenant spec merge")
+	}
+}

--- a/app/scheduler/jobs/scaler_test.go
+++ b/app/scheduler/jobs/scaler_test.go
@@ -1718,6 +1718,63 @@ func TestScaler_MultiTenantVariantsScaleUpIndependently(t *testing.T) {
 	}
 }
 
+// TestScaler_MultiTenantVariantMachineTypeOnJobs verifies setup jobs for a tenant variant
+// carry that tenant's MachineType (not another tenant's).
+func TestScaler_MultiTenantVariantMachineTypeOnJobs(t *testing.T) {
+	instanceStore := NewMockInstanceStore()
+	outboxStore := NewMockOutboxStore()
+	mockPredictor := NewMockPredictor()
+	historyStore := NewMockUtilizationHistoryStore()
+	const image = "ubuntu-2204"
+
+	mockPredictor.SetPredictionForTenant("pool-1", "default", "large", image, 0)
+	mockPredictor.SetPredictionForTenant("pool-1", "acctA", "large", image, 0)
+	for _, tenant := range []string{"default", "acctA"} {
+		historyStore.records = append(historyStore.records, types.UtilizationRecord{
+			Pool: "pool-1", TenantID: tenant, VariantID: "large", ImageName: image,
+			RecordedAt: time.Now().Unix(), InUseInstances: 1,
+		})
+	}
+
+	pools := []ScalablePool{{
+		Name: "pool-1",
+		Tenants: []ScalableTenant{
+			{ID: "default", MinSize: 0, Variants: []ScalableVariant{{
+				MinSize: 1,
+				Params:  types.SetupInstanceParams{VariantID: "large", MachineType: "c4d-standard-8-lssd"},
+			}}},
+			{ID: "acctA", MinSize: 0, Variants: []ScalableVariant{{
+				MinSize: 1,
+				Params:  types.SetupInstanceParams{VariantID: "large", MachineType: "c4d-standard-8"},
+			}}},
+		},
+	}}
+
+	scaler := NewScaler(nil, mockPredictor, instanceStore, historyStore, outboxStore, types.ScalerConfig{
+		WindowDuration: 30 * time.Minute, LeadTime: 5 * time.Minute, Enabled: true, ActiveImageLookbackDays: 7,
+	}, pools, nil)
+
+	now := time.Now()
+	if err := scaler.ScalePool(context.Background(), "pool-1", now.Unix(), now.Add(30*time.Minute).Unix()); err != nil {
+		t.Fatalf("ScalePool: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, job := range outboxStore.GetJobsByType(types.OutboxJobTypeSetupInstance) {
+		var p types.SetupInstanceParams
+		if err := json.Unmarshal(*job.JobParams, &p); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got[p.TenantID] = p.MachineType
+	}
+	if got["default"] != "c4d-standard-8-lssd" {
+		t.Errorf("default machine_type: got %q", got["default"])
+	}
+	if got["acctA"] != "c4d-standard-8" {
+		t.Errorf("acctA machine_type: got %q", got["acctA"])
+	}
+}
+
 // TestScaler_FreeInstanceCounts_BucketedByTenantAndVariant verifies free-instance counting keeps
 // separate buckets per (tenant, variant, image) so one tenant's or variant's inventory is never
 // counted against another's.

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -53,7 +53,10 @@ type (
 		Limit *int `json:"limit,omitempty" yaml:"limit,omitempty"`
 		// Spec is the provider-specific override spec: a subset that is deep-merged over the base.
 		Spec interface{} `json:"spec,omitempty" yaml:"spec,omitempty"`
-		// Variants optionally override the instance-level variants for this tenant.
+		// Variants optionally override the instance-level variants for this tenant. Entries are
+		// matched by variant_id: a matching id fully replaces that base variant, new ids are
+		// appended, and base variants with no override are kept. Omit the list to inherit all
+		// instance-level variants unchanged.
 		Variants []types.PoolVariant `json:"variants,omitempty" yaml:"variants,omitempty"`
 	}
 

--- a/command/config/tenant_merge.go
+++ b/command/config/tenant_merge.go
@@ -29,8 +29,10 @@ type ResolvedTenant struct {
 // The instance-level Spec is the base (default) tenant: it is always returned first with ID
 // "default" and the instance-level Pool/Limit/Variants. Each entry in inst.Tenants is a
 // per-account override whose (partial) Spec is deep-merged over the base; its tenant ID is the
-// first entry of its IDs list, and every account in IDs is routed to that tenant. Accounts not
-// listed in any override resolve to the default tenant.
+// first entry of its IDs list, and every account in IDs is routed to that tenant. Tenant
+// Variants replace matching instance-level variants by variant_id (full entry replace; new
+// variant_ids are appended). Accounts not listed in any override resolve
+// to the default tenant.
 //
 // Backward compatibility: an instance with no `tenants` block resolves to the single default
 // tenant and an empty account map (so every request resolves to the default tenant).
@@ -84,7 +86,7 @@ func ResolveTenants(inst *Instance) (tenants []ResolvedTenant, accountToTenant m
 			Spec:     spec,
 			Pool:     intOrDefault(t.Pool, inst.Pool),
 			Limit:    intOrDefault(t.Limit, inst.Limit),
-			Variants: firstNonEmptyVariants(t.Variants, inst.Variants),
+			Variants: mergeVariants(inst.Variants, t.Variants),
 		})
 
 		for _, accountID := range t.IDs {
@@ -176,11 +178,46 @@ func intOrDefault(p *int, def int) int {
 	return def
 }
 
-func firstNonEmptyVariants(vals ...[]types.PoolVariant) []types.PoolVariant {
-	for _, v := range vals {
-		if len(v) > 0 {
-			return v
-		}
+// mergeVariants merges tenant variant overrides over the instance-level variants by variant_id.
+//
+//   - Empty override → return base unchanged (inherit all).
+//   - Empty base → return override as-is.
+//   - Matching variant_id → the tenant entry fully replaces the base entry.
+//   - New variant_id in override → appended after base variants (in override order).
+//   - Base variants with no matching override → kept as-is.
+func mergeVariants(base, override []types.PoolVariant) []types.PoolVariant {
+	if len(override) == 0 {
+		return base
 	}
-	return nil
+	if len(base) == 0 {
+		return override
+	}
+
+	overrideByID := make(map[string]types.PoolVariant, len(override))
+	overrideOrder := make([]string, 0, len(override))
+	for i := range override {
+		id := override[i].VariantID
+		overrideByID[id] = override[i]
+		overrideOrder = append(overrideOrder, id)
+	}
+
+	seen := make(map[string]bool, len(override))
+	out := make([]types.PoolVariant, 0, len(base)+len(override))
+	for i := range base {
+		id := base[i].VariantID
+		if ov, ok := overrideByID[id]; ok {
+			out = append(out, ov)
+			seen[id] = true
+			continue
+		}
+		out = append(out, base[i])
+	}
+	for _, id := range overrideOrder {
+		if seen[id] {
+			continue
+		}
+		out = append(out, overrideByID[id])
+		seen[id] = true
+	}
+	return out
 }

--- a/command/config/tenant_merge_test.go
+++ b/command/config/tenant_merge_test.go
@@ -442,3 +442,193 @@ func mustMerge(t *testing.T, base, override interface{}) interface{} {
 	}
 	return merged
 }
+
+func TestMergeVariants_EmptyOverrideInheritsBase(t *testing.T) {
+	base := []types.PoolVariant{{
+		Pool: 1,
+		SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", MachineType: "n2-standard-8", ResourceClass: "large",
+		},
+	}}
+	got := mergeVariants(base, nil)
+	if len(got) != 1 || got[0].MachineType != "n2-standard-8" {
+		t.Fatalf("expected base inherited, got %+v", got)
+	}
+	got = mergeVariants(base, []types.PoolVariant{})
+	if len(got) != 1 || got[0].MachineType != "n2-standard-8" {
+		t.Fatalf("empty slice override should inherit base, got %+v", got)
+	}
+}
+
+func TestMergeVariants_EmptyBaseReturnsOverride(t *testing.T) {
+	override := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_flex", MachineType: "n1-standard-1", ResourceClass: "flex"},
+	}}
+	got := mergeVariants(nil, override)
+	if len(got) != 1 || got[0].VariantID != "variant_flex" {
+		t.Fatalf("expected override as-is, got %+v", got)
+	}
+}
+
+func TestMergeVariants_AppendOnlyNewVariantID(t *testing.T) {
+	base := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "n2-standard-8", ResourceClass: "large"},
+	}}
+	override := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_flex", MachineType: "n1-standard-1", ResourceClass: "flex", NestedVirtualization: true},
+	}}
+	got := mergeVariants(base, override)
+	if len(got) != 2 {
+		t.Fatalf("expected base + appended, got %d", len(got))
+	}
+	if got[0].VariantID != "variant_large" || got[1].VariantID != "variant_flex" {
+		t.Errorf("order: got %q then %q", got[0].VariantID, got[1].VariantID)
+	}
+}
+
+func TestMergeVariants_DuplicateOverrideIDsLastWins(t *testing.T) {
+	base := []types.PoolVariant{{
+		SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "n2-standard-8", ResourceClass: "large"},
+	}}
+	override := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "c4d-standard-4", ResourceClass: "large"}},
+		{SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "c4d-standard-8", ResourceClass: "large"}},
+	}
+	got := mergeVariants(base, override)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 variant, got %d", len(got))
+	}
+	if got[0].MachineType != "c4d-standard-8" {
+		t.Errorf("last duplicate should win: got %q", got[0].MachineType)
+	}
+}
+
+func TestMergeVariants_ReplaceByVariantID(t *testing.T) {
+	base := []types.PoolVariant{
+		{
+			Pool: 1, Limit: 5,
+			SetupInstanceParams: types.SetupInstanceParams{
+				VariantID: "variant_large", MachineType: "c4d-standard-8-lssd",
+				DiskType: "hyperdisk-balanced", DiskSize: 100, ResourceClass: "large",
+			},
+		},
+		{
+			Pool: 1, Limit: 5,
+			SetupInstanceParams: types.SetupInstanceParams{
+				VariantID: "variant_xlarge", MachineType: "c4d-standard-8-lssd",
+				DiskType: "hyperdisk-balanced", DiskSize: 100, ResourceClass: "xlarge",
+			},
+		},
+		{
+			Pool: 0, Limit: 0,
+			SetupInstanceParams: types.SetupInstanceParams{
+				VariantID: "variant_xxxlarge", MachineType: "g2-standard-16",
+				GPU: true, ResourceClass: "xxxlarge",
+			},
+		},
+	}
+	// Matching variant_id fully replaces the base entry (not a field merge).
+	override := []types.PoolVariant{{
+		Pool: 2, Limit: 10,
+		SetupInstanceParams: types.SetupInstanceParams{
+			VariantID: "variant_large", MachineType: "c4d-standard-8",
+			DiskType: "hyperdisk-balanced", DiskSize: 100, ResourceClass: "large",
+		},
+	}}
+
+	got := mergeVariants(base, override)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 variants (base length preserved), got %d", len(got))
+	}
+
+	large := got[0]
+	if large.VariantID != "variant_large" {
+		t.Fatalf("order: expected variant_large first, got %q", large.VariantID)
+	}
+	if large.MachineType != "c4d-standard-8" || large.Pool != 2 || large.Limit != 10 {
+		t.Errorf("variant_large should be fully replaced: %+v", large)
+	}
+	if got[1].MachineType != "c4d-standard-8-lssd" || got[1].VariantID != "variant_xlarge" {
+		t.Errorf("unmentioned variant_xlarge must stay unchanged: %+v", got[1])
+	}
+	if !got[2].GPU || got[2].MachineType != "g2-standard-16" {
+		t.Errorf("unmentioned variant_xxxlarge must stay unchanged: %+v", got[2])
+	}
+}
+
+func TestMergeVariants_FullOverrideAndAppend(t *testing.T) {
+	base := []types.PoolVariant{
+		{SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "n2-standard-8", ResourceClass: "large"}},
+		{SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_xlarge", MachineType: "n2-standard-16", ResourceClass: "xlarge"}},
+	}
+	override := []types.PoolVariant{
+		{Pool: 2, SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_large", MachineType: "c2-standard-30", ResourceClass: "large", DiskSize: 200}},
+		{SetupInstanceParams: types.SetupInstanceParams{VariantID: "variant_flex", MachineType: "n1-standard-1", ResourceClass: "flex", NestedVirtualization: true}},
+	}
+
+	got := mergeVariants(base, override)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 (2 base + 1 new), got %d %+v", len(got), got)
+	}
+	if got[0].MachineType != "c2-standard-30" || got[0].Pool != 2 || got[0].ResourceClass != "large" {
+		t.Errorf("variant_large replace: %+v", got[0])
+	}
+	if got[0].DiskSize != 200 {
+		t.Errorf("disk_size: got %d", got[0].DiskSize)
+	}
+	if got[1].VariantID != "variant_xlarge" || got[1].MachineType != "n2-standard-16" {
+		t.Errorf("variant_xlarge should remain: %+v", got[1])
+	}
+	if got[2].VariantID != "variant_flex" || !got[2].NestedVirtualization {
+		t.Errorf("new variant_flex should append: %+v", got[2])
+	}
+}
+
+func TestResolveTenants_ReplaceVariantByID(t *testing.T) {
+	inst := &Instance{
+		Name: "linux-amd64-gcp",
+		Type: "google",
+		Spec: &Google{MachineType: "e2-standard-4", Image: "img-base"},
+		Variants: []types.PoolVariant{
+			{Pool: 1, SetupInstanceParams: types.SetupInstanceParams{
+				VariantID: "variant_large", ResourceClass: "large", MachineType: "c4d-standard-8-lssd", DiskType: "hyperdisk-balanced",
+			}},
+			{Pool: 1, SetupInstanceParams: types.SetupInstanceParams{
+				VariantID: "variant_xlarge", ResourceClass: "xlarge", MachineType: "c4d-standard-16-lssd",
+			}},
+		},
+		Tenants: []Tenant{{
+			IDs:  []string{"acctA"},
+			Spec: &Google{MachineType: "c4d-standard-8"},
+			Variants: []types.PoolVariant{{
+				Pool: 1,
+				SetupInstanceParams: types.SetupInstanceParams{
+					VariantID: "variant_large", ResourceClass: "large", MachineType: "c4d-standard-8", DiskType: "hyperdisk-balanced",
+				},
+			}},
+		}},
+	}
+
+	tenants, _, err := ResolveTenants(inst)
+	if err != nil {
+		t.Fatalf("ResolveTenants: %v", err)
+	}
+	byID := map[string]ResolvedTenant{}
+	for _, tn := range tenants {
+		byID[tn.ID] = tn
+	}
+
+	ta := byID["acctA"]
+	if len(ta.Variants) != 2 {
+		t.Fatalf("acctA should keep both variants after replace-by-id, got %d", len(ta.Variants))
+	}
+	if ta.Variants[0].MachineType != "c4d-standard-8" || ta.Variants[0].ResourceClass != "large" {
+		t.Errorf("variant_large should be replaced: %+v", ta.Variants[0])
+	}
+	if ta.Variants[1].MachineType != "c4d-standard-16-lssd" {
+		t.Errorf("variant_xlarge should be untouched: %+v", ta.Variants[1])
+	}
+	if ta.Spec.(*Google).MachineType != "c4d-standard-8" {
+		t.Errorf("spec machine_type: got %q", ta.Spec.(*Google).MachineType)
+	}
+}

--- a/command/config/tenant_parse_test.go
+++ b/command/config/tenant_parse_test.go
@@ -207,6 +207,79 @@ instances:
 	}
 }
 
+func TestParse_TenantVariantsYAML(t *testing.T) {
+	yaml := `
+version: "1"
+instances:
+  - name: linux-amd64-gcp
+    type: google
+    pool: 1
+    limit: 10
+    spec:
+      account:
+        project_id: proj-base
+      image: img-base
+      machine_type: e2-standard-4
+    variants:
+      - variant_id: variant_large
+        resource_class: large
+        machine_type: c4d-standard-8-lssd
+        disk_type: hyperdisk-balanced
+      - variant_id: variant_xlarge
+        resource_class: xlarge
+        machine_type: c4d-standard-16-lssd
+    tenants:
+      - ids: [acctA]
+        pool: 0
+        spec:
+          machine_type: c4d-standard-8
+        variants:
+          - variant_id: variant_large
+            resource_class: large
+            machine_type: c4d-standard-8
+            disk_type: hyperdisk-balanced
+`
+	pf, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	inst := pf.Instances[0]
+	if len(inst.Variants) != 2 {
+		t.Fatalf("base variants: got %d", len(inst.Variants))
+	}
+	if len(inst.Tenants) != 1 || len(inst.Tenants[0].Variants) != 1 {
+		t.Fatalf("tenant variants: got %+v", inst.Tenants)
+	}
+
+	resolved, accountMap, err := ResolveTenants(&inst)
+	if err != nil {
+		t.Fatalf("ResolveTenants: %v", err)
+	}
+	if accountMap["acctA"] != "acctA" {
+		t.Errorf("account map: %v", accountMap)
+	}
+	byID := map[string]ResolvedTenant{}
+	for _, tn := range resolved {
+		byID[tn.ID] = tn
+	}
+	ta := byID["acctA"]
+	if ta.Pool != 0 {
+		t.Errorf("pool:0 opt-out: got %d", ta.Pool)
+	}
+	if len(ta.Variants) != 2 {
+		t.Fatalf("resolved variants: got %d", len(ta.Variants))
+	}
+	if ta.Variants[0].MachineType != "c4d-standard-8" {
+		t.Errorf("replaced variant_large: got %q", ta.Variants[0].MachineType)
+	}
+	if ta.Variants[1].MachineType != "c4d-standard-16-lssd" {
+		t.Errorf("inherited variant_xlarge: got %q", ta.Variants[1].MachineType)
+	}
+	if ta.Spec.(*Google).MachineType != "c4d-standard-8" {
+		t.Errorf("spec machine_type: got %q", ta.Spec.(*Google).MachineType)
+	}
+}
+
 func TestParse_NoTenantsBackwardCompatible(t *testing.T) {
 	yaml := `
 version: "1"

--- a/command/harness/scalable_pools_test.go
+++ b/command/harness/scalable_pools_test.go
@@ -1,0 +1,93 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/drone-runners/drone-runner-aws/command/config"
+	"github.com/drone-runners/drone-runner-aws/types"
+)
+
+// TestBuildScalablePools_TenantVariantReplaceByID verifies the scaler config path picks up
+// tenant variant machine_type overrides (full replace by variant_id via ResolveTenants).
+func TestBuildScalablePools_TenantVariantReplaceByID(t *testing.T) {
+	yaml := `
+version: "1"
+instances:
+  - name: linux-amd64-gcp
+    type: google
+    pool: 1
+    limit: 10
+    spec:
+      account:
+        project_id: proj-base
+      image: img-base
+      machine_type: e2-standard-4
+    variants:
+      - variant_id: variant_large
+        resource_class: large
+        machine_type: c4d-standard-8-lssd
+        pool: 1
+      - variant_id: variant_xlarge
+        resource_class: xlarge
+        machine_type: c4d-standard-16-lssd
+        pool: 1
+    tenants:
+      - ids: [acctA]
+        pool: 0
+        spec:
+          machine_type: c4d-standard-8
+        variants:
+          - variant_id: variant_large
+            resource_class: large
+            machine_type: c4d-standard-8
+            pool: 2
+`
+	pf, err := config.Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	pools := buildScalablePools(pf)
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool, got %d", len(pools))
+	}
+	p := pools[0]
+	if len(p.Tenants) != 2 {
+		t.Fatalf("expected default + acctA tenants, got %d", len(p.Tenants))
+	}
+
+	byID := map[string]struct {
+		minSize  int
+		variants map[string]string // variant_id -> machine_type
+	}{}
+	for _, tn := range p.Tenants {
+		vm := map[string]string{}
+		for _, v := range tn.Variants {
+			vm[v.Params.VariantID] = v.Params.MachineType
+		}
+		byID[tn.ID] = struct {
+			minSize  int
+			variants map[string]string
+		}{minSize: tn.MinSize, variants: vm}
+	}
+
+	def := byID[types.DefaultTenantID]
+	if def.variants["variant_large"] != "c4d-standard-8-lssd" {
+		t.Errorf("default variant_large: got %q", def.variants["variant_large"])
+	}
+	if def.minSize != 1 {
+		t.Errorf("default minSize: got %d want 1", def.minSize)
+	}
+
+	acct := byID["acctA"]
+	if acct.minSize != 0 {
+		t.Errorf("acctA pool:0 opt-out: got minSize %d", acct.minSize)
+	}
+	if acct.variants["variant_large"] != "c4d-standard-8" {
+		t.Errorf("acctA variant_large machine_type: got %q want c4d-standard-8", acct.variants["variant_large"])
+	}
+	if acct.variants["variant_xlarge"] != "c4d-standard-16-lssd" {
+		t.Errorf("acctA variant_xlarge should inherit base: got %q", acct.variants["variant_xlarge"])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes critical bugs in CI-22905 multi-tenant pool implementation where variant filtering and hibernate operations incorrectly used base pool config instead of tenant-resolved config.

## Root Cause

1. **Variant filtering** called `filterVariants(pool.PoolVariants)` instead of filtering tenant-resolved variants, causing per-tenant `machine_type`, `disk_type`, `image`, and `hibernate` overrides to be ignored at provision time
2. **Hibernate operations** referenced `pool.Driver` instead of `pool.DriverForTenant(tenantID)`, breaking multi-tenant hibernate config

## Changes

### Core fixes
- Add `pool.VariantsForTenant(tenantID)` helper that returns tenant-resolved variants (base variants merged with per-tenant overrides by variant_id)
- Update `filterVariants()` signature to accept `variants []types.PoolVariant` parameter and filter the tenant-resolved list
- Apply `Hibernate` flag from matched variant to `setupParams`
- Route hibernate operations through `pool.DriverForTenant(tenantID)` instead of `pool.Driver` to use tenant-specific `CanHibernate()` and `Hibernate()` implementations

### Test coverage
- `app/drivers/tenant_lifecycle_test.go`: end-to-end test for tenant variant machine_type resolution and merge
- `app/drivers/tenant_hibernate_test.go`: verify hibernate calls route to tenant driver, not default driver
- `app/drivers/pool_test.go`: `VariantsForTenant()` helper logic and `destroyByTenant()` routing
- `app/drivers/distributed_manager_test.go`: tenant-partial machine_type override scenario
- `command/config/tenant_merge_test.go`: per-tenant variant_id merge and override logic
- `command/config/tenant_parse_test.go`: multi-tenant pool config parsing
- `command/harness/scalable_pools_test.go`: scalable pool tenant config
- `app/poolfile/tenant_config_test.go`: poolfile tenant parsing
- `app/scheduler/jobs/scaler_test.go`: scaler tenant awareness

## Testing

All existing tests pass. New tests verify:
- Tenant variant resolution returns the correct merged config (base + override)
- Variant filtering operates on tenant-resolved variants, not base pool variants
- Hibernate operations call tenant-specific driver methods
- Multi-tenant config parsing and validation

## Related Issues

- CI-22905 — Multi-tenant pool feature (merged PR #887)
- Fixes issues discovered during post-merge testing of multi-tenant PrivateLink pools

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*