### PR TITLE
feat: [CI-23936]: Username and password embeding in proxy vars

### DIFF
--- a/app/cloudinit/cloudinit_test.go
+++ b/app/cloudinit/cloudinit_test.go
@@ -140,9 +140,6 @@ func TestLinuxEgressDispatch(t *testing.T) {
 					t.Errorf("v2 template unexpectedly contains v1 envoy marker")
 				}
 				for _, want := range []string{
-					"HTTPS_PROXY=" + proxyURL,
-					"HTTP_PROXY=" + proxyURL,
-					"NO_PROXY=" + noProxy,
 					proxyURL + "/healthz",
 					base64.StdEncoding.EncodeToString([]byte(caCert)),
 				} {
@@ -207,7 +204,7 @@ func TestUbuntuBinariesPartialShared(t *testing.T) {
 		{"egress_v2_diagnostics", func(p *cloudinit.Params) {
 			p.EgressControl = true
 			p.EnableLEDiagnostics = true
-		}, true},
+		}, false},
 	}
 
 	for _, tc := range cases {

--- a/app/cloudinit/user_data/ubuntu_linux_egress_v2
+++ b/app/cloudinit/user_data/ubuntu_linux_egress_v2
@@ -40,38 +40,6 @@ write_files:
   encoding: b64
   content: {{ .EgressCACert | base64 }}
 
-# Docker daemon picks up proxy via systemd drop-in (env vars don't work).
-- path: /etc/systemd/system/docker.service.d/http-proxy.conf
-  permissions: '0644'
-  content: |
-    [Service]
-    Environment="HTTP_PROXY={{ .EgressProxyURL }}"
-    Environment="HTTPS_PROXY={{ .EgressProxyURL }}"
-    Environment="NO_PROXY={{ .EgressNoProxy }}"
-{{ if .EnableLEDiagnostics }}
-- path: /etc/systemd/system/le-pcap.service
-  permissions: '0644'
-  content: |
-    [Unit]
-    Description=Rolling tcpdump for lite-engine port 9079
-    After=network-online.target
-    Wants=network-online.target
-
-    [Service]
-    Type=simple
-    ExecStartPre=/bin/mkdir -p /tmp/le-pcap
-    ExecStart=/usr/bin/tcpdump -i any -s 96 -G 60 -W 30 \
-      -w /tmp/le-pcap/le-%%Y%%m%%d-%%H%%M%%S.pcap \
-      -Z root \
-      'port 9079 or icmp'
-    Restart=always
-    RestartSec=2
-    MemoryMax=64M
-    CPUQuota=10%
-
-    [Install]
-    WantedBy=multi-user.target
-{{ end }}
 # Main runtime commands
 runcmd:
   # Enable command tracing
@@ -86,44 +54,14 @@ runcmd:
 
 {{ template "ubuntu_binaries" . }}
 
-  {{ if .EnableLEDiagnostics }}
-  # Install tcpdump and start a rolling 30-min capture of port-9079 traffic.
-  # Diagnostic aid for cross-region drops affecting RetryStartStep.
-  - |
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tcpdump || true
-    systemctl enable --now le-pcap.service || true
-    systemctl is-active le-pcap.service && echo "le-pcap: active" || echo "le-pcap: NOT RUNNING"
-  {{ end }}
 
   # ────────────────────────────────────────────────────────────────────
-  # ALL bootstrap downloads done. Arm the egress proxy:
-  #   - Append proxy + CA env vars to /etc/environment (DO NOT replace it
-  #     -- the base image's PATH= line lives there and PAM-loaded sessions
-  #     rely on it).
-  #   - Trust the Harness Egress CA (system-wide TLS verify works).
-  #   - Docker daemon restarted to pick up the systemd drop-in.
-  #   - lite-engine inherits the env via --env-file /root/.env.
-  # From here on, all outbound HTTP/S goes through the fleet.
+  # ALL bootstrap downloads done. Trust the Harness Egress CA.
+  # Proxy configuration (docker systemd drop-in + /etc/environment) is
+  # applied by lite-engine at setup time so that per-account credentials
+  # can be embedded. See lite-engine handler/setup.go applyDockerProxy.
   # ────────────────────────────────────────────────────────────────────
-  # Only proxy vars are appended. update-ca-certificates folds the Harness
-  # CA into the system bundle, so curl/git/wget/openssl-using tools just
-  # work. Tools that read their own bundle (Node certifi, Python certifi,
-  # custom git builds) need NODE_EXTRA_CA_CERTS / REQUESTS_CA_BUNDLE /
-  # GIT_SSL_CAINFO / SSL_CERT_FILE -- left to the user to set per-step
-  # since the right value depends on whether they run in a container (own
-  # rootfs, own bundle) vs on the host.
-  - |
-    cat >> /etc/environment <<'EOF'
-    HTTPS_PROXY={{ .EgressProxyURL }}
-    HTTP_PROXY={{ .EgressProxyURL }}
-    https_proxy={{ .EgressProxyURL }}
-    http_proxy={{ .EgressProxyURL }}
-    NO_PROXY={{ .EgressNoProxy }}
-    no_proxy={{ .EgressNoProxy }}
-    EOF
   - update-ca-certificates
-  - systemctl daemon-reload
-  - systemctl restart docker || true
 
   # Egress proxy reachability check. Fails the build VM bootstrap if the
   # fleet ILB is not reachable on the proxy port. /healthz on :3128 is a

--- a/app/cloudinit/user_data/windows_egress
+++ b/app/cloudinit/user_data/windows_egress
@@ -87,36 +87,9 @@ try {
     echo "[egress] git --system config write failed: $($_.Exception.Message)"
 }
 
-echo "[egress] Setting machine-wide proxy env vars"
-# Only proxy vars are set machine-wide. Tools that honour the Windows Cert
-# Store (Schannel-based: curl.exe, git with sslBackend=schannel, .NET, IE,
-# Edge) trust the Harness CA automatically once it's imported above. Tools
-# that read their own bundle (Node certifi, Python certifi, custom git
-# builds via libcurl) need NODE_EXTRA_CA_CERTS / REQUESTS_CA_BUNDLE /
-# GIT_SSL_CAINFO / SSL_CERT_FILE -- left to the user to set per-step
-# since the right value depends on whether the step runs in a container
-# (own rootfs, own bundle) vs on the host.
-[Environment]::SetEnvironmentVariable("HTTPS_PROXY", $EgressProxy,   "Machine")
-[Environment]::SetEnvironmentVariable("HTTP_PROXY",  $EgressProxy,   "Machine")
-[Environment]::SetEnvironmentVariable("NO_PROXY",    $EgressNoProxy, "Machine")
-# Mirror into the current process so the rest of this script (and the
-# lite-engine started below) sees them without a logoff/refresh.
-$env:HTTPS_PROXY = $EgressProxy
-$env:HTTP_PROXY  = $EgressProxy
-$env:NO_PROXY    = $EgressNoProxy
-
-echo "[egress] Restarting Docker so dockerd picks up the new HTTPS_PROXY machine env"
-# Docker on Windows reads HTTPS_PROXY/HTTP_PROXY/NO_PROXY from the service
-# environment on start. We've already set those at Machine scope above; a
-# restart makes the running daemon honour them for registry pulls.
-# (We do NOT write daemon.json -- "proxies" is a Docker CLI config key,
-# the daemon rejects it as an unknown directive and refuses to start.)
-try {
-    Restart-Service docker -Force -ErrorAction Stop
-    echo "[egress] docker restarted"
-} catch {
-    echo "[egress] docker service not running yet; will pick up env on next start"
-}
+# Proxy env vars and docker restart are applied by lite-engine at setup time
+# (lite-engine handler/setup.go applyDockerProxy) so that per-account
+# credentials can be embedded into the proxy URL. See EgressPolicy.ProxyURL.
 
 echo "[egress] Proxy /healthz reachability check"
 # Direct_response 200 from Envoy -- short-circuits before TPA, so it works

--- a/command/config/config.go
+++ b/command/config/config.go
@@ -316,7 +316,7 @@ type (
 // NoProxy and CACert stay global (same for all regions/networks).
 type EgressProxy struct {
 	URL     string `json:"url" yaml:"url" envconfig:"DRONE_EGRESS_PROXY_URL" default:"http://127.0.0.1:3128"`
-	NoProxy string `json:"no_proxy" yaml:"no_proxy" envconfig:"DRONE_EGRESS_NO_PROXY" default:"localhost,127.0.0.1,169.254.169.254,172.16.0.0/12,10.0.0.0/8,.svc.cluster.local"`
+	NoProxy string `json:"no_proxy" yaml:"no_proxy" envconfig:"DRONE_EGRESS_NO_PROXY" default:"localhost,127.0.0.1,169.254.169.254,172.16.0.0/12,10.0.0.0/8,.svc.cluster.local,.harness.io,harness.io"`
 	// CACert is the PEM-encoded Harness Egress CA that signs the leaf certs the
 	// fleet proxy presents. Baked into the build VM so TLS interception is trusted.
 	CACert string `json:"ca_cert" yaml:"ca_cert" envconfig:"DRONE_EGRESS_PROXY_CA_CERT"`
@@ -508,8 +508,8 @@ type EnvConfig struct {
 	}
 
 	LiteEngine struct {
-		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.184/"`
-		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.184/"`
+		Path                string `envconfig:"DRONE_LITE_ENGINE_PATH" default:"https://github.com/harness/lite-engine/releases/download/v0.5.185/"`
+		FallbackPath        string `envconfig:"DRONE_LITE_ENGINE_FALLBACK_PATH" default:"https://app.harness.io/storage/harness-download/harness-ti/harness-lite-engine/v0.5.185/"`
 		EnableMock          bool   `envconfig:"DRONE_LITE_ENGINE_ENABLE_MOCK"`
 		MockStepTimeoutSecs int    `envconfig:"DRONE_LITE_ENGINE_MOCK_STEP_TIMEOUT_SECS" default:"120"`
 	}

--- a/command/harness/helper.go
+++ b/command/harness/helper.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"hash/fnv"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,4 +42,41 @@ func fileID(filename string) string {
 	h := fnv.New32a()
 	h.Write([]byte(filename))
 	return strings.Replace(filepath.Base(filename), ".", "-", -1) + strconv.Itoa(int(h.Sum32()))
+}
+
+// mergeEgressPolicy combines ci-manager-provided credentials with the runner-known proxy URL
+// and noProxy list. Fields are passed through raw — credential embedding into the URL happens
+// at the consumer (lite-engine for docker setup, configureEgressStep for step env vars).
+func mergeEgressPolicy(existing *leapi.EgressPolicy, proxyURL, noProxy string) *leapi.EgressPolicy {
+	if proxyURL == "" {
+		return existing
+	}
+	if existing == nil {
+		return &leapi.EgressPolicy{ProxyURL: proxyURL, NoProxy: noProxy}
+	}
+	return &leapi.EgressPolicy{
+		Username: existing.Username,
+		Password: existing.Password,
+		ProxyURL: proxyURL,
+		NoProxy:  noProxy,
+	}
+}
+
+// buildProxyURL embeds credentials into the proxy URL using net/url so that
+// special characters (@ : % $ etc.) in credentials are percent-encoded correctly.
+// Bare URLs without a scheme are treated as http://.
+func buildProxyURL(username, password, proxyURL string) string {
+	if username == "" || password == "" {
+		return proxyURL
+	}
+	raw := proxyURL
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return proxyURL
+	}
+	u.User = url.UserPassword(username, password)
+	return u.String()
 }

--- a/command/harness/service.go
+++ b/command/harness/service.go
@@ -111,6 +111,7 @@ func (s *VMService) Setup(ctx context.Context, req *SetupVMRequest) (*SetupVMRes
 		s.poolManager,
 		s.metrics,
 		s.fallbackPoolIDs,
+		s.egressProxy.NoProxy,
 	)
 }
 

--- a/command/harness/setup.go
+++ b/command/harness/setup.go
@@ -79,6 +79,7 @@ func HandleSetup(
 	poolManager drivers.IManager,
 	metrics *metric.Metrics,
 	envFallbackPoolIDs []string,
+	noProxy string,
 ) (*SetupVMResponse, string, error) {
 	initStartTime := time.Now()
 	stageRuntimeID := r.ID
@@ -224,7 +225,7 @@ func HandleSetup(
 		pool := fetchPool(r.SetupRequest.LogConfig.AccountID, p, poolMapByAccount)
 		internalLogr.WithField("pool_id", pool).Traceln("starting the setup process")
 		_, _, poolDriver := poolManager.Inspect(p)
-		instance, warmed, hibernated, variantID, poolErr = handleSetup(ctx, logr, internalLogr, r, runnerName, enableMock, mockTimeout, poolManager, pool, owner, capacity)
+		instance, warmed, hibernated, variantID, poolErr = handleSetup(ctx, logr, internalLogr, r, runnerName, enableMock, mockTimeout, poolManager, pool, owner, capacity, noProxy)
 		setupTime = time.Since(st)
 		metrics.WaitDurationCount.WithLabelValues(
 			pool,
@@ -429,6 +430,7 @@ func handleSetup(
 	pool,
 	owner string,
 	reservedCapacity *types.CapacityReservation,
+	noProxy string,
 ) (
 	instance *types.Instance,
 	warmed bool,
@@ -591,6 +593,7 @@ func handleSetup(
 
 	if poolManager.IsEgressPool(pool, instance.TenantID) {
 		r.Volumes = appendEgressCAVolume(r.Volumes, instance.Platform.OS)
+		r.SetupRequest.EgressPolicy = mergeEgressPolicy(r.SetupRequest.EgressPolicy, instance.ProxyURL, noProxy)
 	}
 
 	_, err = client.RetrySetup(ctx, &r.SetupRequest, poolManager.GetSetupTimeout())

--- a/command/harness/step.go
+++ b/command/harness/step.go
@@ -124,7 +124,13 @@ func HandleStep(ctx context.Context,
 		if proxyURL == "" {
 			proxyURL = egressProxy.URL
 		}
-		configureEgressStep(r, inst.Platform.OS, proxyURL, egressProxy.NoProxy)
+		merged := mergeEgressPolicy(r.StartStepRequest.EgressPolicy, proxyURL, egressProxy.NoProxy)
+		if merged != nil {
+			r.StartStepRequest.EgressPolicy = merged
+			configureEgressStep(r, inst.Platform.OS, buildProxyURL(merged.Username, merged.Password, merged.ProxyURL), merged.NoProxy)
+		} else {
+			configureEgressStep(r, inst.Platform.OS, proxyURL, egressProxy.NoProxy)
+		}
 	}
 
 	// Currently the OSX m1 architecture does not enable nested virtualization, so we disable docker.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.5.0
-	github.com/harness/lite-engine v0.5.184
+	github.com/harness/lite-engine v0.5.185
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/nomad/api v0.0.0-20230421025320-b4e6a70fe69b
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/harness/godotenv/v3 v3.0.1 h1:7QPEOkpx6SLLrYRRzPBp50d6c0XIxq721iqoFxbz1Bs=
 github.com/harness/godotenv/v3 v3.0.1/go.mod h1:UIXXJtTM7NkSYMYknHYOO2d8BfDlAWMYZRuRsXcDDR0=
-github.com/harness/lite-engine v0.5.184 h1:wy39Jtd8lcoM8ly8q4Ns5RFnQuJELmPwomNuaxRvEqc=
-github.com/harness/lite-engine v0.5.184/go.mod h1:krHDq6oSVEkRNuN4GSiJmmjSit3kI7VArUqDDBy56GE=
+github.com/harness/lite-engine v0.5.185 h1:fLnrl2aNJtQKP5o3lSg2Vjtlpl2XpV6y6WxiLUq5Qsc=
+github.com/harness/lite-engine v0.5.185/go.mod h1:krHDq6oSVEkRNuN4GSiJmmjSit3kI7VArUqDDBy56GE=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0 h1:J4Na3luGEI1jHnpYzsnDH9/XzVpXPX6x19SGiJZojvo=
 github.com/harness/ti-client v0.0.0-20260106231425-06bf65d965b0/go.mod h1:dGKnH3sg7UvBL2OztrqIusmsiBknSNy1Y5+9M2J241Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=


### PR DESCRIPTION
# Commit Checklist
This pull request refactors how proxy environment variables and credentials are handled for both Linux and Windows build VMs, shifting the responsibility for proxy configuration from the cloud-init/user-data scripts to the `lite-engine` setup phase. This allows proxy credentials to be embedded per-account, increasing flexibility and security. Additionally, helper functions were added for merging and constructing proxy URLs with credentials, and the default `NO_PROXY` list was expanded. The `lite-engine` version is also bumped.

**Proxy configuration refactor:**

* Linux and Windows user-data scripts (`app/cloudinit/user_data/ubuntu_linux_egress_v2`, `app/cloudinit/user_data/windows_egress`) no longer set proxy environment variables or restart Docker directly; instead, proxy setup is delegated to `lite-engine`, allowing per-account credentials to be embedded securely. [[1]](diffhunk://#diff-3768ea02f4e3acd6e99f3494a9dcd21ae983ced7b678b8b9207cb64669606fb6L43-L74) [[2]](diffhunk://#diff-3768ea02f4e3acd6e99f3494a9dcd21ae983ced7b678b8b9207cb64669606fb6L89-L126) [[3]](diffhunk://#diff-d9806c6d6d8b1beef307233e64a3c87b4876d212b25fc43c3691f673de270902L90-R92)
* The helper functions `mergeEgressPolicy` and `buildProxyURL` are introduced in `command/harness/helper.go` to merge credentials and correctly encode them in proxy URLs.
* The step and VM setup code is updated to use these helpers, ensuring merged credentials are used when configuring proxy settings. [[1]](diffhunk://#diff-834cf7886a8aeed52e5fc61db8ba39e2f44d7ac42228ff9eac51612366b1aff9R114) [[2]](diffhunk://#diff-bc0bf69c47e51e7cd69bef20a9e2d1f94e500f7d672f1512fced99561246290eR82) [[3]](diffhunk://#diff-bc0bf69c47e51e7cd69bef20a9e2d1f94e500f7d672f1512fced99561246290eL227-R228) [[4]](diffhunk://#diff-bc0bf69c47e51e7cd69bef20a9e2d1f94e500f7d672f1512fced99561246290eR433) [[5]](diffhunk://#diff-bc0bf69c47e51e7cd69bef20a9e2d1f94e500f7d672f1512fced99561246290eR596) [[6]](diffhunk://#diff-ff67d50315610ba93636c6ad551bde1b0efc18d329a08499e461ca337253b2b3R127-R134)

**Proxy and certificate trust improvements:**

* The default `NO_PROXY` list in `command/config/config.go` is expanded to include `.harness.io` and `harness.io` domains.

**Dependency updates:**

* The default and fallback `lite-engine` versions are updated to `v0.5.185` in both the configuration and Go module files. [[1]](diffhunk://#diff-a8b2009e92d7fb6390adac4990f2236d867e3a5c6fe11743096ccfa942d5b481L511-R512) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L32-R32)
Thank you for creating a pull request! To help us review / merge this can you make sure that your PR adheres as much as possible to the following.

## The Basics

If you are adding new functionality, please provide evidence of the new functionality.
