### PR TITLE
feat: [CI-23161]: inject CA trust env vars for egress proxy MITM

### DIFF
--- a/command/config/config.go
+++ b/command/config/config.go
@@ -323,6 +323,11 @@ type EgressProxy struct {
 	// CACert is the PEM-encoded Harness Egress CA that signs the leaf certs the
 	// fleet proxy presents. Baked into the build VM so TLS interception is trusted.
 	CACert string `json:"ca_cert" yaml:"ca_cert" envconfig:"DRONE_EGRESS_PROXY_CA_CERT"`
+	// CAEnvVars lists environment variables that steps in egress pools get
+	// pointed at the mounted egress CA, so common runtimes and tools
+	// (Go/OpenSSL, Node, Python requests, curl, git) trust TLS interception.
+	// A step-provided value always wins over an injected one.
+	CAEnvVars []string `json:"ca_env_vars" yaml:"ca_env_vars" envconfig:"DRONE_EGRESS_CA_ENV_VARS" default:"SSL_CERT_FILE,NODE_EXTRA_CA_CERTS,REQUESTS_CA_BUNDLE,CURL_CA_BUNDLE,GIT_SSL_CAINFO"`
 }
 
 type EnvConfig struct {

--- a/command/config/egress_proxy_test.go
+++ b/command/config/egress_proxy_test.go
@@ -20,12 +20,29 @@ func TestEgressProxyConfig(t *testing.T) {
 		if !strings.Contains(cfg.Egress.Proxy.NoProxy, "169.254.169.254") {
 			t.Errorf("NoProxy default missing metadata endpoint: %q", cfg.Egress.Proxy.NoProxy)
 		}
+		wantCAEnvVars := []string{
+			"SSL_CERT_FILE",
+			"NODE_EXTRA_CA_CERTS",
+			"REQUESTS_CA_BUNDLE",
+			"CURL_CA_BUNDLE",
+			"GIT_SSL_CAINFO",
+		}
+		got := cfg.Egress.Proxy.CAEnvVars
+		if len(got) != len(wantCAEnvVars) {
+			t.Fatalf("CAEnvVars default = %v, want %v", got, wantCAEnvVars)
+		}
+		for i, v := range wantCAEnvVars {
+			if got[i] != v {
+				t.Errorf("CAEnvVars[%d] = %q, want %q", i, got[i], v)
+			}
+		}
 	})
 
 	t.Run("overrides from env", func(t *testing.T) {
 		t.Setenv("DRONE_EGRESS_PROXY_URL", "http://proxy.example.com:8080")
 		t.Setenv("DRONE_EGRESS_NO_PROXY", "localhost,foo.local")
 		t.Setenv("DRONE_EGRESS_PROXY_CA_CERT", "MY-CA")
+		t.Setenv("DRONE_EGRESS_CA_ENV_VARS", "SSL_CERT_FILE,MY_CUSTOM_CA_VAR")
 
 		cfg, err := FromEnviron()
 		if err != nil {
@@ -39,6 +56,10 @@ func TestEgressProxyConfig(t *testing.T) {
 		}
 		if cfg.Egress.Proxy.CACert != "MY-CA" {
 			t.Errorf("CACert = %q", cfg.Egress.Proxy.CACert)
+		}
+		got := cfg.Egress.Proxy.CAEnvVars
+		if len(got) != 2 || got[0] != "SSL_CERT_FILE" || got[1] != "MY_CUSTOM_CA_VAR" {
+			t.Errorf("CAEnvVars = %v, want [SSL_CERT_FILE MY_CUSTOM_CA_VAR]", got)
 		}
 	})
 }

--- a/command/harness/step.go
+++ b/command/harness/step.go
@@ -127,9 +127,9 @@ func HandleStep(ctx context.Context,
 		merged := mergeEgressPolicy(r.StartStepRequest.EgressPolicy, proxyURL, egressProxy.NoProxy)
 		if merged != nil {
 			r.StartStepRequest.EgressPolicy = merged
-			configureEgressStep(r, inst.Platform.OS, buildProxyURL(merged.Username, merged.Password, merged.ProxyURL), merged.NoProxy)
+			configureEgressStep(r, inst.Platform.OS, buildProxyURL(merged.Username, merged.Password, merged.ProxyURL), merged.NoProxy, egressProxy.CAEnvVars)
 		} else {
-			configureEgressStep(r, inst.Platform.OS, proxyURL, egressProxy.NoProxy)
+			configureEgressStep(r, inst.Platform.OS, proxyURL, egressProxy.NoProxy, egressProxy.CAEnvVars)
 		}
 	}
 
@@ -218,7 +218,9 @@ func setPrevStepExportEnvs(r *ExecuteVMRequest) {
 // configureEgressStep applies the egress-control proxy settings and bind-mounts
 // the Harness egress CA for a step running in an egress pool. It pairs with
 // appendEgressCAVolume (setup side), which registers the host-path volume.
-func configureEgressStep(r *ExecuteVMRequest, os, proxyURL, noProxy string) {
+// caEnvVars lists env vars that get pointed at the mounted CA so common
+// runtimes and tools trust TLS interception (see config.EgressProxy.CAEnvVars).
+func configureEgressStep(r *ExecuteVMRequest, os, proxyURL, noProxy string, caEnvVars []string) {
 	if r.Envs == nil {
 		r.Envs = make(map[string]string)
 	}
@@ -235,6 +237,7 @@ func configureEgressStep(r *ExecuteVMRequest, os, proxyURL, noProxy string) {
 	switch os {
 	case oshelp.OSLinux:
 		r.Envs["HARNESS_CA_PATH"] = egressCAHostPath
+		injectEgressCAEnvVars(r, egressCAHostPath, caEnvVars)
 		r.Volumes = append(r.Volumes, &lespec.VolumeMount{
 			Name: fileID("ca.crt"),
 			Path: egressCAHostPath,
@@ -244,9 +247,24 @@ func configureEgressStep(r *ExecuteVMRequest, os, proxyURL, noProxy string) {
 		// errors "Only directories can be mapped on this platform"). Mount the
 		// parent directory; the CA remains at C:\harness-certs\ca.crt inside.
 		r.Envs["HARNESS_CA_PATH"] = egressCAWindowsHostPath
+		injectEgressCAEnvVars(r, egressCAWindowsHostPath, caEnvVars)
 		r.Volumes = append(r.Volumes, &lespec.VolumeMount{
 			Name: fileID("ca.crt"),
 			Path: "C:\\harness-certs",
 		})
+	}
+}
+
+// injectEgressCAEnvVars points each configured env var at the mounted egress
+// CA. Vars the step already defines are left untouched so users keep control
+// of their toolchain's trust configuration.
+func injectEgressCAEnvVars(r *ExecuteVMRequest, caPath string, caEnvVars []string) {
+	for _, env := range caEnvVars {
+		if env == "" {
+			continue
+		}
+		if _, ok := r.Envs[env]; !ok {
+			r.Envs[env] = caPath
+		}
 	}
 }

--- a/command/harness/step_test.go
+++ b/command/harness/step_test.go
@@ -9,16 +9,27 @@ import (
 // TestConfigureEgressStep verifies the egress-control wiring applied to a step:
 // proxy env vars come from the persisted/instance proxy URL, NO_PROXY is global,
 // the egress CA is always exposed via HARNESS_CA_PATH, and the bind-mount target
-// differs per OS (a file on linux, the parent directory on windows).
+// differs per OS (a file on linux, the parent directory on windows). The
+// configured CA env vars are pointed at the mounted CA per OS, without
+// overriding values the step already defines.
 func TestConfigureEgressStep(t *testing.T) {
 	const (
 		proxyURL = "http://proxy.internal:3128"
 		noProxy  = "localhost,10.0.0.0/8"
 	)
 
+	// Mirrors the config.EgressProxy.CAEnvVars default.
+	defaultCAEnvVars := []string{
+		"SSL_CERT_FILE",
+		"NODE_EXTRA_CA_CERTS",
+		"REQUESTS_CA_BUNDLE",
+		"CURL_CA_BUNDLE",
+		"GIT_SSL_CAINFO",
+	}
+
 	t.Run("linux with proxy URL sets proxy envs, CA path and file volume", func(t *testing.T) {
 		r := &ExecuteVMRequest{}
-		configureEgressStep(r, oshelp.OSLinux, proxyURL, noProxy)
+		configureEgressStep(r, oshelp.OSLinux, proxyURL, noProxy, nil)
 
 		wantEnvs := map[string]string{
 			"HTTPS_PROXY":     proxyURL,
@@ -48,7 +59,7 @@ func TestConfigureEgressStep(t *testing.T) {
 
 	t.Run("empty proxy URL omits proxy envs but still mounts CA", func(t *testing.T) {
 		r := &ExecuteVMRequest{}
-		configureEgressStep(r, oshelp.OSLinux, "", noProxy)
+		configureEgressStep(r, oshelp.OSLinux, "", noProxy, nil)
 
 		for _, k := range []string{"HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy", "NO_PROXY", "no_proxy"} {
 			if _, ok := r.Envs[k]; ok {
@@ -65,7 +76,7 @@ func TestConfigureEgressStep(t *testing.T) {
 
 	t.Run("windows mounts parent cert directory", func(t *testing.T) {
 		r := &ExecuteVMRequest{}
-		configureEgressStep(r, oshelp.OSWindows, proxyURL, noProxy)
+		configureEgressStep(r, oshelp.OSWindows, proxyURL, noProxy, nil)
 
 		if r.Envs["HARNESS_CA_PATH"] != egressCAWindowsHostPath {
 			t.Errorf("HARNESS_CA_PATH = %q, want %q", r.Envs["HARNESS_CA_PATH"], egressCAWindowsHostPath)
@@ -75,6 +86,68 @@ func TestConfigureEgressStep(t *testing.T) {
 		}
 		if r.Volumes[0].Path != `C:\harness-certs` {
 			t.Errorf("volume path = %q, want %q", r.Volumes[0].Path, `C:\harness-certs`)
+		}
+	})
+
+	t.Run("linux injects CA env vars pointing at the mounted CA", func(t *testing.T) {
+		r := &ExecuteVMRequest{}
+		configureEgressStep(r, oshelp.OSLinux, proxyURL, noProxy, defaultCAEnvVars)
+
+		for _, k := range defaultCAEnvVars {
+			if r.Envs[k] != egressCAHostPath {
+				t.Errorf("env %q = %q, want %q", k, r.Envs[k], egressCAHostPath)
+			}
+		}
+	})
+
+	t.Run("windows CA env vars point at the windows CA path", func(t *testing.T) {
+		r := &ExecuteVMRequest{}
+		configureEgressStep(r, oshelp.OSWindows, proxyURL, noProxy, defaultCAEnvVars)
+
+		for _, k := range defaultCAEnvVars {
+			if r.Envs[k] != egressCAWindowsHostPath {
+				t.Errorf("env %q = %q, want %q", k, r.Envs[k], egressCAWindowsHostPath)
+			}
+		}
+	})
+
+	t.Run("step-provided CA env vars are not overridden", func(t *testing.T) {
+		r := &ExecuteVMRequest{}
+		r.Envs = map[string]string{"SSL_CERT_FILE": "/user-provided/ca.pem"}
+		configureEgressStep(r, oshelp.OSLinux, proxyURL, noProxy, defaultCAEnvVars)
+
+		if r.Envs["SSL_CERT_FILE"] != "/user-provided/ca.pem" {
+			t.Errorf("SSL_CERT_FILE = %q, want step-provided value preserved", r.Envs["SSL_CERT_FILE"])
+		}
+		for _, k := range defaultCAEnvVars[1:] {
+			if r.Envs[k] != egressCAHostPath {
+				t.Errorf("env %q = %q, want %q", k, r.Envs[k], egressCAHostPath)
+			}
+		}
+	})
+
+	t.Run("custom list injects only listed vars and skips empty entries", func(t *testing.T) {
+		r := &ExecuteVMRequest{}
+		configureEgressStep(r, oshelp.OSLinux, "", noProxy, []string{"REQUESTS_CA_BUNDLE", ""})
+
+		if r.Envs["REQUESTS_CA_BUNDLE"] != egressCAHostPath {
+			t.Errorf("REQUESTS_CA_BUNDLE = %q, want %q", r.Envs["REQUESTS_CA_BUNDLE"], egressCAHostPath)
+		}
+		for _, k := range []string{"SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO", ""} {
+			if _, ok := r.Envs[k]; ok {
+				t.Errorf("env %q should not be set", k)
+			}
+		}
+	})
+
+	t.Run("nil CA env list injects no CA env vars", func(t *testing.T) {
+		r := &ExecuteVMRequest{}
+		configureEgressStep(r, oshelp.OSLinux, proxyURL, noProxy, nil)
+
+		for _, k := range defaultCAEnvVars {
+			if _, ok := r.Envs[k]; ok {
+				t.Errorf("env %q should not be set when CA env list is nil", k)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Enables automatic CA trust for egress proxy MITM inspection by injecting standard environment variables that point to the mounted egress CA certificate.

## Problem

Customer requires all egress traffic from Harness Hosted Cloud Build VMs to route through a central proxy with MITM certificate authority trust. While the egress CA is already mounted at a known path (`HARNESS_CA_PATH`), common runtimes and tools (Go/OpenSSL, Node, Python requests, curl, git) need explicit configuration via environment variables to trust it.

## Root Cause

The egress control implementation (CI-23161) mounts the CA certificate but doesn't configure the standard environment variables that various runtimes use to locate custom CA bundles. This requires users to manually configure their toolchain's CA trust, creating friction and inconsistent behavior across different language ecosystems.

## Solution

Introduce a configurable list of CA environment variables (`CAEnvVars`) that get automatically injected to point at the mounted egress CA. The implementation:

1. Adds `EgressProxy.CAEnvVars` config field with sensible defaults covering major ecosystems
2. Injects these env vars during step configuration, pointing them at the OS-appropriate CA path
3. Never overrides user-provided values, preserving control over toolchain configuration
4. Supports both Linux (`/harness-certs/ca.crt`) and Windows (`C:\harness-certs\ca.crt`) paths

## Changes Made

- **command/config/config.go**: Added `CAEnvVars []string` field to `EgressProxy` struct with default list: `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`
- **command/harness/step.go**: 
  - Updated `configureEgressStep` to accept `caEnvVars` parameter
  - Added `injectEgressCAEnvVars` helper that injects CA env vars without overriding existing values
  - Applied injection for both Linux and Windows paths
- **Tests**: Comprehensive coverage for all scenarios (8 test cases)
  - Default CA env var injection for Linux/Windows
  - User override preservation
  - Custom/nil CA env var lists
  - Empty entry handling

## Testing

All tests pass, including:
- ✅ `TestEgressProxyConfig`: Config parsing with defaults and overrides
- ✅ `TestConfigureEgressStep`: All 8 scenarios for CA env var injection
- ✅ Full test suite: All 24 packages tested successfully

## Related Issues/Logs

- JIRA: [CI-23161](https://harness.atlassian.net/browse/CI-23161)
- Customer: Huntington National Bank (HNB) egress control requirement
- Related PR: [#873](https://github.com/drone-runners/drone-runner-aws/pull/873) (initial egress proxy support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CI-23161]: https://harness.atlassian.net/browse/CI-23161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ