### PR TITLE
fix: [CI-24128]: remove incorrect StageRuntimeID override causing lite-engine panic

### DIFF
--- a/command/harness/step.go
+++ b/command/harness/step.go
@@ -160,9 +160,6 @@ func HandleStep(ctx context.Context,
 			}
 		}
 	}
-	if r.StartStepRequest.StageRuntimeID == "" {
-		r.StartStepRequest.StageRuntimeID = r.StageRuntimeID
-	}
 	startStepResponse, err := client.RetryStartStep(ctx, &r.StartStepRequest, poolManager.GetStartStepTimeout())
 	if err != nil {
 		return nil, fmt.Errorf("failed to call LE.RetryStartStep: %w", err)


### PR DESCRIPTION
## Problem

Customer's Windows CI builds were hanging indefinitely after the `harness-git-clone` step completed. The EC2 VM would provision successfully and git operations would finish in ~23 seconds, but the pipeline never advanced to the next step. After ~60 minutes, the stage was marked `EXPIRED` by independent timeouts in both PMS and the delegate.

## Root Cause

Lite-engine was experiencing a nil pointer panic in `dlite/delegate.(*TokenCache).Get(0x0)`. The panic occurred because `StartStepRequest.StageRuntimeID` was being incorrectly overwritten with `r.StageRuntimeID` (line 163-165), which could be empty or wrong. This caused lite-engine to crash silently inside the VM and never report step completion back to the delegate, resulting in the ~60-minute timeout hang.

Ken Ng confirmed this root cause through multiple occurrences:
- Original execution `smAGIcvqSUSm-Xc8VPxnBw` (runSequence 56)
- Fresh recurrence `bbfNhF-MS2OQJDmq-dXejw` showing identical panic signature

## Solution

Remove the 3-line block (lines 163-165) that was incorrectly overwriting `StartStepRequest.StageRuntimeID`. The `StageRuntimeID` should remain as originally set in `StartStepRequest` to prevent lite-engine panics.

## Changes Made

- **command/harness/step.go**: Removed lines 163-165 that were setting `r.StartStepRequest.StageRuntimeID = r.StageRuntimeID`

## Testing

- ✅ Build passes: `go build ./...`
- ✅ Unit tests pass: `go test ./command/harness/... -v -count=1`
- ✅ Pre-push hook tests pass

## Related Issues/Logs

- **Ticket**: [CI-24128](https://harness.atlassian.net/browse/CI-24128) (P1)
- **Zendesk**: https://harnesssupport.zendesk.com/agent/tickets/120890
- **Related ticket**: CI-22520 (similar hang symptom, but different root cause)
- **Delegate log**: https://cloudlogging.app.goo.gl/Vo7pBWaNKsq5Hdjq7
- **PMS log**: https://cloudlogging.app.goo.gl/i24vmnhLGBHvdmUf8

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-24128]: https://harness.atlassian.net/browse/CI-24128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ